### PR TITLE
Evaluate Comparison Expressions with Constant Operands during Compilation

### DIFF
--- a/src/sema/eval.rs
+++ b/src/sema/eval.rs
@@ -729,6 +729,150 @@ pub(crate) fn eval_constants_in_expression(
                 (None, true)
             }
         }
+        Expression::More {
+            loc,
+            left,
+            right,
+        } => {
+            let left = eval_constants_in_expression(left, diagnostics).0;
+            let right = eval_constants_in_expression(right, diagnostics).0;
+
+            if let (
+                Some(Expression::NumberLiteral { value: left, .. }),
+                Some(Expression::NumberLiteral { value: right, .. }),
+            ) = (&left, &right)
+            {
+                (
+                    Some(Expression::BoolLiteral { 
+                        loc: *loc,
+                        value: left > right
+                    }),
+                    true,
+                )
+            } else {
+                (None, true)
+            }
+        }
+        Expression::Less {
+            loc,
+            left,
+            right,
+        } => {
+            let left = eval_constants_in_expression(left, diagnostics).0;
+            let right = eval_constants_in_expression(right, diagnostics).0;
+
+            if let (
+                Some(Expression::NumberLiteral { value: left, .. }),
+                Some(Expression::NumberLiteral { value: right, .. }),
+            ) = (&left, &right)
+            {
+                (
+                    Some(Expression::BoolLiteral { 
+                        loc: *loc,
+                        value: left < right
+                    }),
+                    true,
+                )
+            } else {
+                (None, true)
+            }
+        }
+        Expression::Equal {
+            loc,
+            left,
+            right,
+        } => {
+            let left = eval_constants_in_expression(left, diagnostics).0;
+            let right = eval_constants_in_expression(right, diagnostics).0;
+
+            if let (
+                Some(Expression::NumberLiteral { value: left, .. }),
+                Some(Expression::NumberLiteral { value: right, .. }),
+            ) = (&left, &right)
+            {
+                (
+                    Some(Expression::BoolLiteral { 
+                        loc: *loc,
+                        value: left == right
+                    }),
+                    true,
+                )
+            } else {
+                (None, true)
+            }
+        }
+        Expression::NotEqual {
+            loc,
+            left,
+            right,
+        } => {
+            let left = eval_constants_in_expression(left, diagnostics).0;
+            let right = eval_constants_in_expression(right, diagnostics).0;
+
+            if let (
+                Some(Expression::NumberLiteral { value: left, .. }),
+                Some(Expression::NumberLiteral { value: right, .. }),
+            ) = (&left, &right)
+            {
+                (
+                    Some(Expression::BoolLiteral { 
+                        loc: *loc,
+                        value: left != right
+                    }),
+                    true,
+                )
+            } else {
+                (None, true)
+            }
+        }
+        Expression::MoreEqual {
+            loc,
+            left,
+            right,
+        } => {
+            let left = eval_constants_in_expression(left, diagnostics).0;
+            let right = eval_constants_in_expression(right, diagnostics).0;
+
+            if let (
+                Some(Expression::NumberLiteral { value: left, .. }),
+                Some(Expression::NumberLiteral { value: right, .. }),
+            ) = (&left, &right)
+            {
+                (
+                    Some(Expression::BoolLiteral { 
+                        loc: *loc,
+                        value: left >= right 
+                    }),
+                    true,
+                )
+            } else {
+                (None, true)
+            }
+        }
+        Expression::LessEqual {
+            loc,
+            left,
+            right,
+        } => {
+            let left = eval_constants_in_expression(left, diagnostics).0;
+            let right = eval_constants_in_expression(right, diagnostics).0;
+
+            if let (
+                Some(Expression::NumberLiteral { value: left, .. }),
+                Some(Expression::NumberLiteral { value: right, .. }),
+            ) = (&left, &right)
+            {
+                (
+                    Some(Expression::BoolLiteral { 
+                        loc: *loc,
+                        value: left <= right 
+                    }),
+                    true,
+                )
+            } else {
+                (None, true)
+            }
+        }
         Expression::ZeroExt { loc, to, expr } => {
             let expr = eval_constants_in_expression(expr, diagnostics).0;
             if let Some(Expression::NumberLiteral { value, .. }) = expr {

--- a/tests/codegen_testcases/solidity/const_expr_eval.sol
+++ b/tests/codegen_testcases/solidity/const_expr_eval.sol
@@ -1,0 +1,11 @@
+// RUN: --target polkadot --emit cfg
+contract ConstExprEvaluate {
+    // BEGIN-CHECK: ConstExprEvaluate::ConstExprEvaluate::function::less
+    function less() public pure returns (bool r) {
+        int a = 100;
+        int b = 200;
+
+        // CHECK: r = true
+        r = a < b;
+    }
+}


### PR DESCRIPTION
This patch supports evaluation of comparison expressions with constants as operands during compile time.

Fixes #755 