### PR TITLE
Add Constructor Support for Solang Solidity Contracts on Soroban

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -41,7 +41,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ make
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-linux-arm64.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-linux-arm64.tar.xz
     - name: Extract LLVM
@@ -74,7 +74,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm16.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
       with:
         components: clippy
     - name: Build
@@ -97,7 +97,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-mac-arm.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -124,7 +124,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Get LLVM
       run: wget -q -O llvm16.0-mac-intel.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
         echo "$(pwd)/bin" >> $GITHUB_PATH
     
     - name: Install Soroban
-      run: cargo install --locked soroban-cli --version 21.0.0-rc.1
+      run: cargo install --locked soroban-cli --version 22.0.0
     - name: Add cargo install location to PATH
       run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.75.0
+        toolchain: 1.81.0
         components: |
           llvm-tools
           clippy
@@ -120,7 +120,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ make
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-linux-arm64.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-linux-arm64.tar.xz
     - name: Extract LLVM
@@ -153,7 +153,7 @@ jobs:
     # Use C:\ as D:\ might run out of space
     - name: "Use C: for rust temporary files"
       run: echo "CARGO_TARGET_DIR=C:\target" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
       with:
         components: clippy
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
@@ -179,7 +179,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-mac-arm.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -205,7 +205,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Get LLVM
       run: wget -q -O llvm16.0-mac-intel.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-intel.tar.xz
     - name: Extract LLVM
@@ -267,7 +267,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - name: Setup yarn
       run: npm install -g yarn
     - uses: actions/download-artifact@v4.1.8
@@ -318,7 +318,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - uses: actions/download-artifact@v4.1.8
       with:
         name: solang-linux-x86-64
@@ -360,7 +360,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.81.0
     - uses: actions/download-artifact@v4.1.8
       with:
         name: solang-linux-x86-64
@@ -537,7 +537,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: 1.81.0
           components: llvm-tools
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ forge-fmt = { path = "fmt", optional = true }
 # We don't use ethers-core directly, but need the correct version for the
 # build to work.
 ethers-core = { version = "2.0.10", optional = true }
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"], optional = true }
+soroban-sdk = { version = "22.0.0-rc.3.2", features = ["testutils"], optional = true }
 
 [dev-dependencies]
 num-derive = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 build = "build.rs"
 description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "polkadot", "substrate" ]
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 edition = "2021"
 exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode", "/testdata" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . src
 WORKDIR /src/stdlib/
 RUN make
 
-RUN rustup default 1.75.0
+RUN rustup default 1.81.0
 
 WORKDIR /src
 RUN cargo build --release

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -89,7 +89,7 @@ Option 5: Build Solang from source
 
 In order to build Solang from source, you will need:
 
-* Rust version 1.75.0 or higher
+* Rust version 1.81.0 or higher
 * A C++ compiler with support for C++17
 * A build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
 

--- a/integration/soroban/counter.spec.js
+++ b/integration/soroban/counter.spec.js
@@ -30,10 +30,6 @@ describe('Counter', () => {
 
     // load contract
     contract = new StellarSdk.Contract(contractAddr);
-
-    // initialize the contract
-    await call_contract_function("init", server, keypair, contract);
-
   });
 
   it('get correct initial counter', async () => {

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -59,6 +59,9 @@ impl SorobanEnv {
     }
 
     pub fn register_contract(&mut self, contract_wasm: Vec<u8>) -> Address {
+        // For now, we keep using `register_contract_wasm`. To use `register`, we have to figure
+        // out first what to pass for `constructor_args`
+        #[allow(deprecated)]
         let addr = self
             .env
             .register_contract_wasm(None, contract_wasm.as_slice());

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -32,7 +32,7 @@ pub fn build_solidity(src: &str) -> SorobanEnv {
             log_prints: true,
             #[cfg(feature = "wasm_opt")]
             wasm_opt: Some(contract_build::OptimizationPasses::Z),
-            soroban_version: Some(85899345977),
+            soroban_version: None,
             ..Default::default()
         },
         std::vec!["unknown".to_string()],

--- a/tests/soroban_testcases/print.rs
+++ b/tests/soroban_testcases/print.rs
@@ -18,8 +18,6 @@ fn log_runtime_error() {
 
     let addr = src.contracts.last().unwrap();
 
-    let _res = src.invoke_contract(addr, "init", vec![]);
-
     src.invoke_contract(addr, "decrement", vec![]);
 
     let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
@@ -39,8 +37,6 @@ fn print() {
     );
 
     let addr = src.contracts.last().unwrap();
-
-    let _res = src.invoke_contract(addr, "init", vec![]);
 
     src.invoke_contract(addr, "print", vec![]);
 
@@ -64,8 +60,6 @@ fn print_then_runtime_error() {
     );
 
     let addr = src.contracts.last().unwrap();
-
-    let _res = src.invoke_contract(addr, "init", vec![]);
 
     src.invoke_contract(addr, "decrement", vec![]);
 

--- a/tests/soroban_testcases/storage.rs
+++ b/tests/soroban_testcases/storage.rs
@@ -23,8 +23,6 @@ fn counter() {
 
     let addr = src.contracts.last().unwrap();
 
-    let _res = src.invoke_contract(addr, "init", vec![]);
-
     let res = src.invoke_contract(addr, "count", vec![]);
     let expected: Val = 10_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));


### PR DESCRIPTION
This PR is the first step towards implementing #1672. It adds constructor support for Solidity contracts in Solang. The next step, not covered in this PR, is handling cases where the user defines a `__constructor` function with custom logic. More details can be found in the issue discussion.

### Changes Made
- Renamed the `init` function (used to call `storage_initializers`) to `__constructor` so that it is recognized and invoked by the Soroban host environment.
- Updated tests and CI to work with Soroban version 22.