### PR TITLE
Soroban: Support for Constructors

### DIFF
--- a/integration/soroban/.gitignore
+++ b/integration/soroban/.gitignore
@@ -1,4 +1,3 @@
-*.js
 *.so
 *.key
 *.json

--- a/integration/soroban/constructor_no_args.sol
+++ b/integration/soroban/constructor_no_args.sol
@@ -1,0 +1,11 @@
+contract noargsconstructor {
+    uint64 public count = 1;
+
+    constructor() {
+        count += 1;
+    }
+
+    function get() public view returns (uint64) {
+        return count;
+    }
+}

--- a/integration/soroban/noargsconstructor.spec.js
+++ b/integration/soroban/noargsconstructor.spec.js
@@ -1,0 +1,41 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { readFileSync } from 'fs';
+import { expect } from 'chai';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { call_contract_function } from './test_helpers.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(__filename);
+
+describe('CounterWithNoArgsConstructor', () => {
+  let keypair;
+  const server = new StellarSdk.SorobanRpc.Server(
+    "https://soroban-testnet.stellar.org:443",
+  );
+
+  let contractAddr;
+  let contract;
+  before(async () => {
+
+    console.log('Setting up counter with no-args constructor contract tests...');
+
+    // read secret from file
+    const secret = readFileSync('alice.txt', 'utf8').trim();
+    keypair = StellarSdk.Keypair.fromSecret(secret);
+
+    let contractIdFile = path.join(dirname, '.soroban', 'contract-ids', 'noargsconstructor.txt');
+    // read contract address from file
+    contractAddr = readFileSync(contractIdFile, 'utf8').trim().toString();
+
+    // load contract
+    contract = new StellarSdk.Contract(contractAddr);
+  });
+
+  it('make sure the constructor of the contract was called', async () => {
+    // get the count
+    let count = await call_contract_function("get", server, keypair, contract);
+    expect(count.toString()).eq("2");
+  });
+
+});

--- a/integration/soroban/setup.js
+++ b/integration/soroban/setup.js
@@ -60,4 +60,5 @@ function add_testnet() {
 
 add_testnet();
 generate_alice();
+// FIXME: This will need to be refactored to allow providing constructor arguments for a specific contract
 deploy_all();

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -16,7 +16,8 @@ pub struct SorobanEnv {
     contracts: Vec<Address>,
 }
 
-pub fn build_solidity(src: &str) -> SorobanEnv {
+/// Compile a Solidity contract and return the compiled WASM blob.
+pub fn build_solidity(src: &str) -> Vec<u8> {
     let tmp_file = OsStr::new("test.sol");
     let mut cache = FileResolver::default();
     cache.set_file_contents(tmp_file.to_str().unwrap(), src.to_string());
@@ -41,10 +42,11 @@ pub fn build_solidity(src: &str) -> SorobanEnv {
     ns.print_diagnostics_in_plain(&cache, false);
     assert!(!wasm.is_empty());
     let wasm_blob = wasm[0].0.clone();
-    SorobanEnv::new_with_contract(wasm_blob)
+    wasm_blob
 }
 
 impl SorobanEnv {
+    /// Create a new Soroban environment.
     pub fn new() -> Self {
         Self {
             env: Env::default(),
@@ -52,23 +54,30 @@ impl SorobanEnv {
         }
     }
 
-    pub fn new_with_contract(contract_wasm: Vec<u8>) -> Self {
+    /// Create a new Soroban environment with a contract.
+    pub fn new_with_contract(
+        contract_wasm: Vec<u8>,
+        constructor_args: soroban_sdk::Vec<Val>,
+    ) -> Self {
         let mut env = Self::new();
-        env.register_contract(contract_wasm);
+        env.register_contract(contract_wasm, constructor_args);
         env
     }
 
-    pub fn register_contract(&mut self, contract_wasm: Vec<u8>) -> Address {
-        // For now, we keep using `register_contract_wasm`. To use `register`, we have to figure
-        // out first what to pass for `constructor_args`
-        #[allow(deprecated)]
+    /// Register a contract given its WASM blob and constructor arguments.
+    pub fn register_contract(
+        &mut self,
+        contract_wasm: Vec<u8>,
+        constructor_args: soroban_sdk::Vec<Val>,
+    ) -> Address {
         let addr = self
             .env
-            .register_contract_wasm(None, contract_wasm.as_slice());
+            .register(contract_wasm.as_slice(), constructor_args);
         self.contracts.push(addr.clone());
         addr
     }
 
+    /// Invoke a contract and return the result.
     pub fn invoke_contract(&self, addr: &Address, function_name: &str, args: Vec<Val>) -> Val {
         let func = Symbol::new(&self.env, function_name);
         let mut args_soroban = vec![&self.env];

--- a/tests/soroban_testcases/constructor.rs
+++ b/tests/soroban_testcases/constructor.rs
@@ -1,0 +1,92 @@
+use crate::{build_solidity, SorobanEnv};
+use soroban_sdk::testutils::Logs;
+use soroban_sdk::{IntoVal, Val};
+
+#[test]
+fn test_constructor_increments_count() {
+    let wasm = build_solidity(
+        r#"contract counter {
+            uint64 public count = 1;
+
+            constructor() {
+                count += 1;
+            }
+
+            function get() public view returns (uint64) {
+                return count;
+            }
+        }"#,
+    );
+    let mut src = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    let address = src.register_contract(wasm, constructor_args);
+
+    let res = src.invoke_contract(&address, "get", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
+    assert!(
+        expected.shallow_eq(&res),
+        "expected: {:?}, got: {:?}",
+        expected,
+        res
+    );
+}
+
+#[test]
+fn test_constructor_logs_message_on_call() {
+    let wasm = build_solidity(
+        r#"contract counter {
+            uint64 public count = 1;
+
+            constructor() {
+                print("Constructor called");
+            }
+
+            function get() public view returns (uint64) {
+                return count;
+            }
+        }"#,
+    );
+    let mut src = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    let address = src.register_contract(wasm, constructor_args);
+
+    let _res = src.invoke_contract(&address, "get", vec![]);
+
+    let logs = src.env.logs().all();
+    assert!(logs[0].contains("Constructor called"));
+}
+
+// FIXME: Uncomment this test once the constructor arguments are supported
+// #[test]
+fn _test_constructor_set_count_value() {
+    let wasm = build_solidity(
+        r#"contract counter {
+            uint64 public count = 1;
+
+            constructor(uint64 initial_count) {
+                count = initial_count;
+            }
+
+            function get() public view returns (uint64) {
+                return count;
+            }
+        }"#,
+    );
+    let mut src = SorobanEnv::new();
+    let mut constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    constructor_args.push_back(42_u64.into_val(&src.env));
+    let address = src.register_contract(wasm, constructor_args);
+
+    // Get the value of count and check it is 42
+    let res = src.invoke_contract(&address, "get", vec![]);
+    let expected: Val = 42_u64.into_val(&src.env);
+
+    assert!(
+        expected.shallow_eq(&res),
+        "expected: {:?}, got: {:?}",
+        expected,
+        res
+    );
+}

--- a/tests/soroban_testcases/math.rs
+++ b/tests/soroban_testcases/math.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::build_solidity;
+use crate::{build_solidity, SorobanEnv};
 use soroban_sdk::{IntoVal, Val};
 
 #[test]
 fn math() {
-    let runtime = build_solidity(
+    let wasm = build_solidity(
         r#"contract math {
         function max(uint64 a, uint64 b) public returns (uint64) {
             if (a > b) {
@@ -16,20 +16,23 @@ fn math() {
         }
     }"#,
     );
+    let mut env = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&env.env);
+    let address = env.register_contract(wasm, constructor_args);
 
-    let arg: Val = 5_u64.into_val(&runtime.env);
-    let arg2: Val = 4_u64.into_val(&runtime.env);
+    let arg: Val = 5_u64.into_val(&env.env);
+    let arg2: Val = 4_u64.into_val(&env.env);
 
-    let addr = runtime.contracts.last().unwrap();
-    let res = runtime.invoke_contract(addr, "max", vec![arg, arg2]);
+    let res = env.invoke_contract(&address, "max", vec![arg, arg2]);
 
-    let expected: Val = 5_u64.into_val(&runtime.env);
+    let expected: Val = 5_u64.into_val(&env.env);
     assert!(expected.shallow_eq(&res));
 }
 
 #[test]
 fn math_same_name() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract math {
         function max(uint64 a, uint64 b) public returns (uint64) {
             if (a > b) {
@@ -38,7 +41,7 @@ fn math_same_name() {
                 return b;
             }
         }
-    
+
         function max(uint64 a, uint64 b, uint64 c) public returns (uint64) {
             if (a > b) {
                 if (a > c) {
@@ -57,19 +60,21 @@ fn math_same_name() {
     }
     "#,
     );
-
-    let addr = src.contracts.last().unwrap();
+    let mut src = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    let address = src.register_contract(wasm, constructor_args);
 
     let arg1: Val = 5_u64.into_val(&src.env);
     let arg2: Val = 4_u64.into_val(&src.env);
-    let res = src.invoke_contract(addr, "max_uint64_uint64", vec![arg1, arg2]);
+    let res = src.invoke_contract(&address, "max_uint64_uint64", vec![arg1, arg2]);
     let expected: Val = 5_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
     let arg1: Val = 5_u64.into_val(&src.env);
     let arg2: Val = 4_u64.into_val(&src.env);
     let arg3: Val = 6_u64.into_val(&src.env);
-    let res = src.invoke_contract(addr, "max_uint64_uint64_uint64", vec![arg1, arg2, arg3]);
+    let res = src.invoke_contract(&address, "max_uint64_uint64_uint64", vec![arg1, arg2, arg3]);
     let expected: Val = 6_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 }

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+mod constructor;
 mod math;
 mod print;
 mod storage;

--- a/tests/soroban_testcases/print.rs
+++ b/tests/soroban_testcases/print.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::build_solidity;
-use soroban_sdk::testutils::Logs;
+use crate::{build_solidity, SorobanEnv};
+use soroban_sdk::{testutils::Logs, Val};
 
 #[test]
 fn log_runtime_error() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract counter {
             uint64 public count = 1;
         
@@ -15,19 +15,21 @@ fn log_runtime_error() {
             }
         }"#,
     );
+    let mut env = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&env.env);
+    let address = env.register_contract(wasm, constructor_args);
 
-    let addr = src.contracts.last().unwrap();
+    env.invoke_contract(&address, "decrement", vec![]);
 
-    src.invoke_contract(addr, "decrement", vec![]);
-
-    let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
+    let logs = env.invoke_contract_expect_error(&address, "decrement", vec![]);
 
     assert!(logs[0].contains("runtime_error: math overflow in test.sol:5:17-27"));
 }
 
 #[test]
 fn print() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract Printer {
 
             function print() public {
@@ -35,10 +37,12 @@ fn print() {
             }
         }"#,
     );
+    let mut src = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    let address = src.register_contract(wasm, constructor_args);
 
-    let addr = src.contracts.last().unwrap();
-
-    src.invoke_contract(addr, "print", vec![]);
+    src.invoke_contract(&address, "print", vec![]);
 
     let logs = src.env.logs().all();
 
@@ -47,10 +51,10 @@ fn print() {
 
 #[test]
 fn print_then_runtime_error() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract counter {
             uint64 public count = 1;
-        
+
             function decrement() public returns (uint64){
                 print("Second call will FAIL!");
                 count -= 1;
@@ -58,12 +62,14 @@ fn print_then_runtime_error() {
             }
         }"#,
     );
+    let mut src = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    let address = src.register_contract(wasm, constructor_args);
 
-    let addr = src.contracts.last().unwrap();
+    src.invoke_contract(&address, "decrement", vec![]);
 
-    src.invoke_contract(addr, "decrement", vec![]);
-
-    let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
+    let logs = src.invoke_contract_expect_error(&address, "decrement", vec![]);
 
     assert!(logs[0].contains("Second call will FAIL!"));
     assert!(logs[1].contains("Second call will FAIL!"));

--- a/tests/soroban_testcases/storage.rs
+++ b/tests/soroban_testcases/storage.rs
@@ -1,39 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::build_solidity;
+use crate::{build_solidity, SorobanEnv};
 use soroban_sdk::{IntoVal, Val};
 
 #[test]
 fn counter() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract counter {
             uint64 public count = 10;
-        
+
             function increment() public returns (uint64){
                 count += 1;
                 return count;
             }
-        
+
             function decrement() public returns (uint64){
                 count -= 1;
                 return count;
             }
         }"#,
     );
+    let mut src = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&src.env);
+    let address = src.register_contract(wasm, constructor_args);
 
-    let addr = src.contracts.last().unwrap();
-
-    let res = src.invoke_contract(addr, "count", vec![]);
+    let res = src.invoke_contract(&address, "count", vec![]);
     let expected: Val = 10_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    src.invoke_contract(addr, "increment", vec![]);
-    let res = src.invoke_contract(addr, "count", vec![]);
+    src.invoke_contract(&address, "increment", vec![]);
+    let res = src.invoke_contract(&address, "count", vec![]);
     let expected: Val = 11_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    src.invoke_contract(addr, "decrement", vec![]);
-    let res = src.invoke_contract(addr, "count", vec![]);
+    src.invoke_contract(&address, "decrement", vec![]);
+    let res = src.invoke_contract(&address, "count", vec![]);
     let expected: Val = 10_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 }


### PR DESCRIPTION
This PR adds support for user-defined constructors in Soroban, specifically for constructors with no arguments. Note that constructors with arguments are not yet supported (see comments for details).
Part of #1672

**Other changes include:**
- Refactored code in `tests/soroban.rs` to allow providing constructors when registering contracts on the chain.
- Added tests for constructors in `tests/soroban_testcases/constructor.rs`.
