### PR TITLE
Fixes two `elided_named_lifetimes` warnings

### DIFF
--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -372,7 +372,7 @@ impl ast::Contract {
         context: &'a inkwell::context::Context,
         opt: &'a Options,
         contract_no: usize,
-    ) -> binary::Binary {
+    ) -> binary::Binary<'a> {
         binary::Binary::build(context, self, ns, opt, contract_no)
     }
 

--- a/src/sema/builtin_structs.rs
+++ b/src/sema/builtin_structs.rs
@@ -240,7 +240,7 @@ pub static BUILTIN_STRUCTS: Lazy<[BuiltinStructDeclaration; 3]> = Lazy::new(|| {
 });
 
 impl StructType {
-    pub fn definition<'a>(&'a self, ns: &'a Namespace) -> &StructDecl {
+    pub fn definition<'a>(&'a self, ns: &'a Namespace) -> &'a StructDecl {
         match self {
             StructType::UserDefined(struct_no) => &ns.structs[*struct_no],
             StructType::AccountInfo => &BUILTIN_STRUCTS[0].struct_decl,


### PR DESCRIPTION
When I build Solang, I see these two warnings:
```
warning: elided lifetime has a name
   --> src/emit/mod.rs:375:18
    |
369 |     pub fn binary<'a>(
    |                   -- lifetime `'a` declared here
...
375 |     ) -> binary::Binary {
    |                  ^^^^^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default

warning: elided lifetime has a name
   --> src/sema/builtin_structs.rs:243:59
    |
243 |     pub fn definition<'a>(&'a self, ns: &'a Namespace) -> &StructDecl {
    |                       -- lifetime `'a` declared here      ^ this elided lifetime gets resolved as `'a`
```
This PR addresses both of the warnings.