### PR TITLE
Fix/err

### DIFF
--- a/integration/polkadot/balances.spec.ts
+++ b/integration/polkadot/balances.spec.ts
@@ -31,7 +31,7 @@ describe('Deploy balances contract and test', () => {
         let { data: { free: contractQueryBalBefore } } = await conn.query.system.account(String(deploy_contract.address));
 
         // The "Existential Deposit" (aka. minimum balance) is part of the free balance;
-        // to get the actual free balance from a contracts point of view we substract it.
+        // to get the actual free balance from a contracts point of view we subtract it.
         const ED = 1000000000n;
         expect(contractRpcBal?.toString()).toBe((contractQueryBalBefore.toBigInt() - ED).toString());
 

--- a/integration/subxt-tests/README.md
+++ b/integration/subxt-tests/README.md
@@ -1,6 +1,6 @@
 # Solang `subxt` integration test suite
 
-This directroy contains integration tests against a real node using `subxt`.
+This directory contains integration tests against a real node using `subxt`.
 
 ## How to execute the tests
 


### PR DESCRIPTION
# Fix: Corrected typos in integration files

## Changes
- `integration\subxt-tests\README.md:3`: "directroy" changed to "directory".
- `integration\polkadot\balances.spec.ts:34`: "substract" changed to "subtract".

## Purpose
- To ensure correctness and maintain professionalism.
