### PR TITLE
Soroban: Add `extendTtl` Builtin Method 

### DIFF
--- a/docs/language/builtins.rst
+++ b/docs/language/builtins.rst
@@ -666,3 +666,31 @@ Assuming `arg1` is 512 and `arg2` is 196, the output to the log will be ``foo en
     When formatting integers in to decimals, types larger than 64 bits require expensive division.
     Be mindful this will increase the gas cost. Larger values will incur a higher gas cost.
     Alternatively, use a hexadecimal ``{:x}`` format specifier to reduce the cost.
+
+.. _extendPersistentTtl:
+
+extendPersistentTtl(uint32 threshold, uint32 extend_to) 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The ``extendPersistentTtl()`` method allows extending the time-to-live (TTL) of a contract storage entry.
+
+If the entry's TTL is below threshold ledgers, this function updates ``live_until_ledger_seq`` such that TTL equals ``extend_to``. The TTL is defined as:
+
+.. math::
+
+TTL = live_until_ledger_seq - current_ledger
+
+
+.. note:: This method is only available on the Soroban target
+
+.. code-block:: solidity
+
+    /// Extends the TTL for the `count` persistent key to 5000 ledgers
+    /// if the current TTL is smaller than 1000 ledgers
+    function extend_ttl() public view returns (int64) {
+        return count.extendPersistentTtl(1000, 5000);
+    }
+
+
+
+For more details on managing contract data TTLs in Soroban, refer to the docs for `TTL <https://developers.stellar.org/docs/build/smart-contracts/getting-started/storing-data#managing-contract-data-ttls-with-extend_ttl>`_.

--- a/docs/language/builtins.rst
+++ b/docs/language/builtins.rst
@@ -667,7 +667,6 @@ Assuming `arg1` is 512 and `arg2` is 196, the output to the log will be ``foo en
     Be mindful this will increase the gas cost. Larger values will incur a higher gas cost.
     Alternatively, use a hexadecimal ``{:x}`` format specifier to reduce the cost.
 
-.. _extendPersistentTtl:
 
 extendTtl(uint32 threshold, uint32 extend_to) 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -694,3 +693,20 @@ TTL = live_until_ledger_seq - current_ledger
 
 
 For more details on managing contract data TTLs in Soroban, refer to the docs for `TTL <https://developers.stellar.org/docs/build/smart-contracts/getting-started/storing-data#managing-contract-data-ttls-with-extend_ttl>`_.
+
+extendInstanceTtl(uint32 threshold, uint32 extend_to)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The extendInstanceTtl() function extends the time-to-live (TTL) of contract instance storage.
+
+If the TTL for the current contract instance and code (if applicable) is below threshold ledgers, this function extends ``live_until_ledger_seq`` such that TTL equals ``extend_to``.
+
+.. note:: This is a global function, not a method, and is only available on the Soroban target
+
+.. code-block:: solidity
+
+    /// Extends the TTL for the contract instance storage to 10000 ledgers
+    /// if the current TTL is smaller than 2000 ledgers
+    function extendInstanceTtl() public view returns (int64) {
+        return extendInstanceTtl(2000, 10000);
+    }

--- a/docs/language/builtins.rst
+++ b/docs/language/builtins.rst
@@ -669,10 +669,10 @@ Assuming `arg1` is 512 and `arg2` is 196, the output to the log will be ``foo en
 
 .. _extendPersistentTtl:
 
-extendPersistentTtl(uint32 threshold, uint32 extend_to) 
+extendTtl(uint32 threshold, uint32 extend_to) 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The ``extendPersistentTtl()`` method allows extending the time-to-live (TTL) of a contract storage entry.
+The ``extendTtl()`` method allows extending the time-to-live (TTL) of a contract storage entry.
 
 If the entry's TTL is below threshold ledgers, this function updates ``live_until_ledger_seq`` such that TTL equals ``extend_to``. The TTL is defined as:
 
@@ -688,7 +688,7 @@ TTL = live_until_ledger_seq - current_ledger
     /// Extends the TTL for the `count` persistent key to 5000 ledgers
     /// if the current TTL is smaller than 1000 ledgers
     function extend_ttl() public view returns (int64) {
-        return count.extendPersistentTtl(1000, 5000);
+        return count.extendTtl(1000, 5000);
     }
 
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1794,6 +1794,7 @@ pub enum Builtin {
     WriteUint256LE,
     WriteBytes,
     Concat,
+    ExtendPersistentTtl,
 }
 
 impl From<&ast::Builtin> for Builtin {
@@ -1856,6 +1857,7 @@ impl From<&ast::Builtin> for Builtin {
             ast::Builtin::PrevRandao => Builtin::PrevRandao,
             ast::Builtin::ContractCode => Builtin::ContractCode,
             ast::Builtin::StringConcat | ast::Builtin::BytesConcat => Builtin::Concat,
+            ast::Builtin::ExtendPersistentTtl => Builtin::ExtendPersistentTtl,
             _ => panic!("Builtin should not be in the cfg"),
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1796,7 +1796,7 @@ pub enum Builtin {
     WriteUint256LE,
     WriteBytes,
     Concat,
-    ExtendPersistentTtl,
+    ExtendTtl,
 }
 
 impl From<&ast::Builtin> for Builtin {
@@ -1859,7 +1859,7 @@ impl From<&ast::Builtin> for Builtin {
             ast::Builtin::PrevRandao => Builtin::PrevRandao,
             ast::Builtin::ContractCode => Builtin::ContractCode,
             ast::Builtin::StringConcat | ast::Builtin::BytesConcat => Builtin::Concat,
-            ast::Builtin::ExtendPersistentTtl => Builtin::ExtendPersistentTtl,
+            ast::Builtin::ExtendTtl => Builtin::ExtendTtl,
             _ => panic!("Builtin should not be in the cfg"),
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -98,6 +98,7 @@ pub enum HostFunctions {
     PutContractData,
     GetContractData,
     ExtendContractDataTtl,
+    ExtendCurrentContractInstanceAndCodeTtl,
     LogFromLinearMemory,
     SymbolNewFromLinearMemory,
     VectorNew,
@@ -113,6 +114,7 @@ impl HostFunctions {
             HostFunctions::PutContractData => "l._",
             HostFunctions::GetContractData => "l.1",
             HostFunctions::ExtendContractDataTtl => "l.7",
+            HostFunctions::ExtendCurrentContractInstanceAndCodeTtl => "l.8",
             HostFunctions::LogFromLinearMemory => "x._",
             HostFunctions::SymbolNewFromLinearMemory => "b.j",
             HostFunctions::VectorNew => "v._",
@@ -1797,6 +1799,7 @@ pub enum Builtin {
     WriteBytes,
     Concat,
     ExtendTtl,
+    ExtendInstanceTtl,
 }
 
 impl From<&ast::Builtin> for Builtin {
@@ -1860,6 +1863,7 @@ impl From<&ast::Builtin> for Builtin {
             ast::Builtin::ContractCode => Builtin::ContractCode,
             ast::Builtin::StringConcat | ast::Builtin::BytesConcat => Builtin::Concat,
             ast::Builtin::ExtendTtl => Builtin::ExtendTtl,
+            ast::Builtin::ExtendInstanceTtl => Builtin::ExtendInstanceTtl,
             _ => panic!("Builtin should not be in the cfg"),
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -97,6 +97,7 @@ impl From<inkwell::OptimizationLevel> for OptimizationLevel {
 pub enum HostFunctions {
     PutContractData,
     GetContractData,
+    ExtendContractDataTtl,
     LogFromLinearMemory,
     SymbolNewFromLinearMemory,
     VectorNew,
@@ -111,6 +112,7 @@ impl HostFunctions {
         match self {
             HostFunctions::PutContractData => "l._",
             HostFunctions::GetContractData => "l.1",
+            HostFunctions::ExtendContractDataTtl => "l.7",
             HostFunctions::LogFromLinearMemory => "x._",
             HostFunctions::SymbolNewFromLinearMemory => "b.j",
             HostFunctions::VectorNew => "v._",

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -59,7 +59,7 @@ fn test_builtin_conversion() {
         ast::Builtin::WriteUint256LE,
         ast::Builtin::WriteString,
         ast::Builtin::WriteBytes,
-        ast::Builtin::ExtendPersistentTtl,
+        ast::Builtin::ExtendTtl,
     ];
 
     let output: Vec<codegen::Builtin> = vec![
@@ -116,7 +116,7 @@ fn test_builtin_conversion() {
         codegen::Builtin::WriteUint256LE,
         codegen::Builtin::WriteBytes,
         codegen::Builtin::WriteBytes,
-        codegen::Builtin::ExtendPersistentTtl,
+        codegen::Builtin::ExtendTtl,
     ];
 
     for (i, item) in input.iter().enumerate() {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -60,6 +60,7 @@ fn test_builtin_conversion() {
         ast::Builtin::WriteString,
         ast::Builtin::WriteBytes,
         ast::Builtin::ExtendTtl,
+        ast::Builtin::ExtendInstanceTtl,
     ];
 
     let output: Vec<codegen::Builtin> = vec![
@@ -117,6 +118,7 @@ fn test_builtin_conversion() {
         codegen::Builtin::WriteBytes,
         codegen::Builtin::WriteBytes,
         codegen::Builtin::ExtendTtl,
+        codegen::Builtin::ExtendInstanceTtl,
     ];
 
     for (i, item) in input.iter().enumerate() {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -59,6 +59,7 @@ fn test_builtin_conversion() {
         ast::Builtin::WriteUint256LE,
         ast::Builtin::WriteString,
         ast::Builtin::WriteBytes,
+        ast::Builtin::ExtendPersistentTtl,
     ];
 
     let output: Vec<codegen::Builtin> = vec![
@@ -115,6 +116,7 @@ fn test_builtin_conversion() {
         codegen::Builtin::WriteUint256LE,
         codegen::Builtin::WriteBytes,
         codegen::Builtin::WriteBytes,
+        codegen::Builtin::ExtendPersistentTtl,
     ];
 
     for (i, item) in input.iter().enumerate() {

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -39,6 +39,13 @@ impl HostFunctions {
                 .context
                 .i64_type()
                 .fn_type(&[ty.into(), ty.into()], false),
+            // https://github.com/stellar/stellar-protocol/blob/2fdc77302715bc4a31a784aef1a797d466965024/core/cap-0046-03.md#ledger-host-functions-mod-l
+            // ;; If the entry's TTL is below `threshold` ledgers, extend `live_until_ledger_seq` such that TTL == `extend_to`, where TTL is defined as live_until_ledger_seq - current ledger.
+            // (func $extend_contract_data_ttl (param $k_val i64) (param $t_storage_type i64) (param $threshold_u32_val i64) (param $extend_to_u32_val i64) (result i64))
+            HostFunctions::ExtendContractDataTtl => bin
+                .context
+                .i64_type()
+                .fn_type(&[ty.into(), ty.into(), ty.into(), ty.into()], false),
             HostFunctions::LogFromLinearMemory => bin
                 .context
                 .i64_type()
@@ -279,6 +286,7 @@ impl SorobanTarget {
         let host_functions = [
             HostFunctions::PutContractData,
             HostFunctions::GetContractData,
+            HostFunctions::ExtendContractDataTtl,
             HostFunctions::LogFromLinearMemory,
             HostFunctions::SymbolNewFromLinearMemory,
             HostFunctions::VectorNew,

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -46,6 +46,12 @@ impl HostFunctions {
                 .context
                 .i64_type()
                 .fn_type(&[ty.into(), ty.into(), ty.into(), ty.into()], false),
+            // ;; If the TTL for the current contract instance and code (if applicable) is below `threshold` ledgers, extend `live_until_ledger_seq` such that TTL == `extend_to`, where TTL is defined as live_until_ledger_seq - current ledger.
+            // (func $extend_current_contract_instance_and_code_ttl (param $threshold_u32_val i64) (param $extend_to_u32_val i64) (result i64))
+            HostFunctions::ExtendCurrentContractInstanceAndCodeTtl => bin
+                .context
+                .i64_type()
+                .fn_type(&[ty.into(), ty.into()], false),
             HostFunctions::LogFromLinearMemory => bin
                 .context
                 .i64_type()
@@ -287,6 +293,7 @@ impl SorobanTarget {
             HostFunctions::PutContractData,
             HostFunctions::GetContractData,
             HostFunctions::ExtendContractDataTtl,
+            HostFunctions::ExtendCurrentContractInstanceAndCodeTtl,
             HostFunctions::LogFromLinearMemory,
             HostFunctions::SymbolNewFromLinearMemory,
             HostFunctions::VectorNew,

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -17,9 +17,10 @@ use inkwell::values::{
     ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FunctionValue, IntValue,
     PointerValue,
 };
-use num_traits::ToPrimitive;
 
 use solang_parser::pt::{Loc, StorageType};
+
+use num_traits::ToPrimitive;
 
 use std::collections::HashMap;
 
@@ -509,7 +510,8 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
                 let extend_to_u32_val = (extend_to << 32) + 4;
 
                 // Call the function
-                let function_value = bin.module.get_function(EXTEND_CONTRACT_DATA_TTL).unwrap();
+                let function_name = HostFunctions::ExtendContractDataTtl.name();
+                let function_value = bin.module.get_function(function_name).unwrap();
 
                 let value = bin
                     .builder
@@ -527,7 +529,7 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
                                 .const_int(extend_to_u32_val, false)
                                 .into(),
                         ],
-                        EXTEND_CONTRACT_DATA_TTL,
+                        function_name,
                     )
                     .unwrap()
                     .try_as_basic_value()

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -467,14 +467,13 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
 
         match expr {
             Expression::Builtin {
-                kind: Builtin::ExtendPersistentTtl,
+                kind: Builtin::ExtendTtl,
                 args,
                 ..
             } => {
                 // Get arguments
                 // (func $extend_contract_data_ttl (param $k_val i64) (param $t_storage_type i64) (param $threshold_u32_val i64) (param $extend_to_u32_val i64) (result i64))
-                let storage_type = storage_type_to_int(&Some(StorageType::Persistent(None)));
-                assert_eq!(args.len(), 3, "extendPersistentTtl expects 3 arguments");
+                assert_eq!(args.len(), 4, "extendTtl expects 4 arguments");
                 // SAFETY: We already checked that the length of args is 3 so it is safe to unwrap here
                 let slot_no = match args.first().unwrap() {
                     Expression::NumberLiteral { value, .. } => value,
@@ -500,6 +499,15 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
                         "Expected extend_to to be of type Expression::NumberLiteral. Actual: {:?}",
                         args.get(2).unwrap()
                     ),
+                }
+                .to_u64()
+                .unwrap();
+                let storage_type = match args.get(3).unwrap() {
+                    Expression::NumberLiteral { value, .. } => value,
+                    _ => panic!(
+                    "Expected storage_type to be of type Expression::NumberLiteral. Actual: {:?}",
+                    args.get(3).unwrap()
+                ),
                 }
                 .to_u64()
                 .unwrap();

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -476,20 +476,29 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
                 assert_eq!(args.len(), 3, "extendPersistentTtl expects 3 arguments");
                 // SAFETY: We already checked that the length of args is 3 so it is safe to unwrap here
                 let slot_no = match args.first().unwrap() {
-                    Expression::FunctionArg { arg_no, .. } => *arg_no,
-                    _ => panic!("Expected slot_no to be of type Expression::FunctionArg"),
+                    Expression::NumberLiteral { value, .. } => value,
+                    _ => panic!(
+                        "Expected slot_no to be of type Expression::NumberLiteral. Actual: {:?}",
+                        args.get(1).unwrap()
+                    ),
                 }
                 .to_u64()
                 .unwrap();
                 let threshold = match args.get(1).unwrap() {
                     Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!("Expected threshold to be of type Expression::NumberLiteral"),
+                    _ => panic!(
+                        "Expected threshold to be of type Expression::NumberLiteral. Actual: {:?}",
+                        args.get(1).unwrap()
+                    ),
                 }
                 .to_u64()
                 .unwrap();
                 let extend_to = match args.get(2).unwrap() {
                     Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!("Expected extend_to to be of type Expression::NumberLiteral"),
+                    _ => panic!(
+                        "Expected extend_to to be of type Expression::NumberLiteral. Actual: {:?}",
+                        args.get(2).unwrap()
+                    ),
                 }
                 .to_u64()
                 .unwrap();

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1780,6 +1780,7 @@ pub enum Builtin {
     TypeRuntimeCode,
     TypeCreatorCode,
     ExtendTtl,
+    ExtendInstanceTtl,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1779,7 +1779,7 @@ pub enum Builtin {
     TypeInterfaceId,
     TypeRuntimeCode,
     TypeCreatorCode,
-    ExtendPersistentTtl,
+    ExtendTtl,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1779,6 +1779,7 @@ pub enum Builtin {
     TypeInterfaceId,
     TypeRuntimeCode,
     TypeCreatorCode,
+    ExtendPersistentTtl,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -547,8 +547,20 @@ pub static BUILTIN_VARIABLE: Lazy<[Prototype; 17]> = Lazy::new(|| {
 });
 
 // A list of all Solidity builtins methods
-pub static BUILTIN_METHODS: Lazy<[Prototype; 27]> = Lazy::new(|| {
+pub static BUILTIN_METHODS: Lazy<[Prototype; 28]> = Lazy::new(|| {
     [
+        Prototype {
+            builtin: Builtin::ExtendPersistentTtl,
+            namespace: None, 
+            // FIXME: For now as a PoC, we are only supporting this method for type `uint64`
+            method: vec![Type::Uint(64)], 
+            name: "extendPersistentTtl",
+            params: vec![Type::Uint(32), Type::Uint(32)], // Parameters `threshold` and `extend_to` of type `uint32`
+            ret: vec![Type::Int(64)], 
+            target: vec![Target::Soroban], 
+            doc: "If the entry's TTL is below `threshold` ledgers, extend `live_until_ledger_seq` such that TTL == `extend_to`, where TTL is defined as live_until_ledger_seq - current ledger.",
+            constant: false,
+        },
         Prototype {
             builtin: Builtin::ReadInt8,
             namespace: None,

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -36,8 +36,19 @@ pub struct Prototype {
 }
 
 // A list of all Solidity builtins functions
-pub static BUILTIN_FUNCTIONS: Lazy<[Prototype; 27]> = Lazy::new(|| {
+pub static BUILTIN_FUNCTIONS: Lazy<[Prototype; 28]> = Lazy::new(|| {
     [
+        Prototype {
+            builtin: Builtin::ExtendInstanceTtl,
+            namespace: None,
+            method: vec![],
+            name: "extend_instance_ttl",  
+            params: vec![Type::Uint(32), Type::Uint(32)],
+            ret: vec![Type::Int(64)],
+            target: vec![Target::Soroban],
+            doc: "If the TTL for the current contract instance and code (if applicable) is below `threshold` ledgers, extend `live_until_ledger_seq` such that TTL == `extend_to`, where TTL is defined as live_until_ledger_seq - current ledger.",
+            constant: false,
+        },
         Prototype {
             builtin: Builtin::Assert,
             namespace: None,

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -550,11 +550,11 @@ pub static BUILTIN_VARIABLE: Lazy<[Prototype; 17]> = Lazy::new(|| {
 pub static BUILTIN_METHODS: Lazy<[Prototype; 28]> = Lazy::new(|| {
     [
         Prototype {
-            builtin: Builtin::ExtendPersistentTtl,
+            builtin: Builtin::ExtendTtl,
             namespace: None,
             // FIXME: For now as a PoC, we are only supporting this method for type `uint64`
             method: vec![Type::StorageRef(false, Box::new(Type::Uint(64)))],
-            name: "extendPersistentTtl",
+            name: "extendTtl",
             params: vec![Type::Uint(32), Type::Uint(32)], // Parameters `threshold` and `extend_to` of type `uint32`
             ret: vec![Type::Int(64)],
             target: vec![Target::Soroban],

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -42,7 +42,7 @@ pub static BUILTIN_FUNCTIONS: Lazy<[Prototype; 28]> = Lazy::new(|| {
             builtin: Builtin::ExtendInstanceTtl,
             namespace: None,
             method: vec![],
-            name: "extend_instance_ttl",  
+            name: "extendInstanceTtl",  
             params: vec![Type::Uint(32), Type::Uint(32)],
             ret: vec![Type::Int(64)],
             target: vec![Target::Soroban],

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -551,13 +551,13 @@ pub static BUILTIN_METHODS: Lazy<[Prototype; 28]> = Lazy::new(|| {
     [
         Prototype {
             builtin: Builtin::ExtendPersistentTtl,
-            namespace: None, 
+            namespace: None,
             // FIXME: For now as a PoC, we are only supporting this method for type `uint64`
             method: vec![Type::StorageRef(false, Box::new(Type::Uint(64)))],
             name: "extendPersistentTtl",
             params: vec![Type::Uint(32), Type::Uint(32)], // Parameters `threshold` and `extend_to` of type `uint32`
-            ret: vec![Type::Int(64)], 
-            target: vec![Target::Soroban], 
+            ret: vec![Type::Int(64)],
+            target: vec![Target::Soroban],
             doc: "If the entry's TTL is below `threshold` ledgers, extend `live_until_ledger_seq` such that TTL == `extend_to`, where TTL is defined as live_until_ledger_seq - current ledger.",
             constant: false,
         },

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -553,7 +553,7 @@ pub static BUILTIN_METHODS: Lazy<[Prototype; 28]> = Lazy::new(|| {
             builtin: Builtin::ExtendPersistentTtl,
             namespace: None, 
             // FIXME: For now as a PoC, we are only supporting this method for type `uint64`
-            method: vec![Type::Uint(64)], 
+            method: vec![Type::StorageRef(false, Box::new(Type::Uint(64)))],
             name: "extendPersistentTtl",
             params: vec![Type::Uint(32), Type::Uint(32)], // Parameters `threshold` and `extend_to` of type `uint32`
             ret: vec![Type::Int(64)], 

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -25,10 +25,7 @@ where
 {
     let (wasm_blob, ns) = build_wasm(src);
 
-    let env =
-        SorobanEnv::new_with_contract(wasm_blob, configure_env).insert_diagnostics(ns.diagnostics);
-
-    env
+    SorobanEnv::new_with_contract(wasm_blob, configure_env).insert_diagnostics(ns.diagnostics)
 }
 
 fn build_wasm(src: &str) -> (Vec<u8>, Namespace) {

--- a/tests/soroban_testcases/cross_contract_calls.rs
+++ b/tests/soroban_testcases/cross_contract_calls.rs
@@ -15,6 +15,7 @@ fn simple_cross_contract() {
             }
         }
     }"#,
+        |_| {},
     );
 
     let caller = runtime.deploy_contract(

--- a/tests/soroban_testcases/math.rs
+++ b/tests/soroban_testcases/math.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::build_solidity;
+use crate::{build_solidity, SorobanEnv};
 use soroban_sdk::{IntoVal, Val};
 
 #[test]
 fn math() {
-    let runtime = build_solidity(
+    let wasm = build_solidity(
         r#"contract math {
         function max(uint64 a, uint64 b) public returns (uint64) {
             if (a > b) {
@@ -17,11 +17,15 @@ fn math() {
     }"#,
     );
 
+    let mut runtime = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
+    let addr = runtime.register_contract(wasm, constructor_args);
+
     let arg: Val = 5_u64.into_val(&runtime.env);
     let arg2: Val = 4_u64.into_val(&runtime.env);
 
-    let addr = runtime.contracts.last().unwrap();
-    let res = runtime.invoke_contract(addr, "max", vec![arg, arg2]);
+    let res = runtime.invoke_contract(&addr, "max", vec![arg, arg2]);
 
     let expected: Val = 5_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
@@ -29,7 +33,7 @@ fn math() {
 
 #[test]
 fn math_same_name() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract math {
         function max(uint64 a, uint64 b) public returns (uint64) {
             if (a > b) {
@@ -58,18 +62,21 @@ fn math_same_name() {
     "#,
     );
 
-    let addr = src.contracts.last().unwrap();
+    let mut runtime = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
+    let addr = runtime.register_contract(wasm, constructor_args);
 
-    let arg1: Val = 5_u64.into_val(&src.env);
-    let arg2: Val = 4_u64.into_val(&src.env);
-    let res = src.invoke_contract(addr, "max_uint64_uint64", vec![arg1, arg2]);
-    let expected: Val = 5_u64.into_val(&src.env);
+    let arg1: Val = 5_u64.into_val(&runtime.env);
+    let arg2: Val = 4_u64.into_val(&runtime.env);
+    let res = runtime.invoke_contract(&addr, "max_uint64_uint64", vec![arg1, arg2]);
+    let expected: Val = 5_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let arg1: Val = 5_u64.into_val(&src.env);
-    let arg2: Val = 4_u64.into_val(&src.env);
-    let arg3: Val = 6_u64.into_val(&src.env);
-    let res = src.invoke_contract(addr, "max_uint64_uint64_uint64", vec![arg1, arg2, arg3]);
-    let expected: Val = 6_u64.into_val(&src.env);
+    let arg1: Val = 5_u64.into_val(&runtime.env);
+    let arg2: Val = 4_u64.into_val(&runtime.env);
+    let arg3: Val = 6_u64.into_val(&runtime.env);
+    let res = runtime.invoke_contract(&addr, "max_uint64_uint64_uint64", vec![arg1, arg2, arg3]);
+    let expected: Val = 6_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 }

--- a/tests/soroban_testcases/math.rs
+++ b/tests/soroban_testcases/math.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{build_solidity, SorobanEnv};
+use crate::build_solidity;
 use soroban_sdk::{IntoVal, Val};
 
 #[test]
 fn math() {
-    let wasm = build_solidity(
+    let runtime = build_solidity(
         r#"contract math {
         function max(uint64 a, uint64 b) public returns (uint64) {
             if (a > b) {
@@ -15,17 +15,14 @@ fn math() {
             }
         }
     }"#,
+        |_| {},
     );
-
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
 
     let arg: Val = 5_u64.into_val(&runtime.env);
     let arg2: Val = 4_u64.into_val(&runtime.env);
 
-    let res = runtime.invoke_contract(&addr, "max", vec![arg, arg2]);
+    let addr = runtime.contracts.last().unwrap();
+    let res = runtime.invoke_contract(addr, "max", vec![arg, arg2]);
 
     let expected: Val = 5_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
@@ -33,7 +30,7 @@ fn math() {
 
 #[test]
 fn math_same_name() {
-    let wasm = build_solidity(
+    let src = build_solidity(
         r#"contract math {
         function max(uint64 a, uint64 b) public returns (uint64) {
             if (a > b) {
@@ -60,23 +57,21 @@ fn math_same_name() {
         }
     }
     "#,
+        |_| {},
     );
 
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
+    let addr = src.contracts.last().unwrap();
 
-    let arg1: Val = 5_u64.into_val(&runtime.env);
-    let arg2: Val = 4_u64.into_val(&runtime.env);
-    let res = runtime.invoke_contract(&addr, "max_uint64_uint64", vec![arg1, arg2]);
-    let expected: Val = 5_u64.into_val(&runtime.env);
+    let arg1: Val = 5_u64.into_val(&src.env);
+    let arg2: Val = 4_u64.into_val(&src.env);
+    let res = src.invoke_contract(addr, "max_uint64_uint64", vec![arg1, arg2]);
+    let expected: Val = 5_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let arg1: Val = 5_u64.into_val(&runtime.env);
-    let arg2: Val = 4_u64.into_val(&runtime.env);
-    let arg3: Val = 6_u64.into_val(&runtime.env);
-    let res = runtime.invoke_contract(&addr, "max_uint64_uint64_uint64", vec![arg1, arg2, arg3]);
-    let expected: Val = 6_u64.into_val(&runtime.env);
+    let arg1: Val = 5_u64.into_val(&src.env);
+    let arg2: Val = 4_u64.into_val(&src.env);
+    let arg3: Val = 6_u64.into_val(&src.env);
+    let res = src.invoke_contract(addr, "max_uint64_uint64_uint64", vec![arg1, arg2, arg3]);
+    let expected: Val = 6_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 }

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -3,3 +3,4 @@ mod cross_contract_calls;
 mod math;
 mod print;
 mod storage;
+mod ttl;

--- a/tests/soroban_testcases/print.rs
+++ b/tests/soroban_testcases/print.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{build_solidity, SorobanEnv};
-use soroban_sdk::{testutils::Logs, Val};
+use crate::build_solidity;
+use soroban_sdk::testutils::Logs;
 
 #[test]
 fn log_runtime_error() {
-    let wasm = build_solidity(
+    let src = build_solidity(
         r#"contract counter {
             uint64 public count = 1;
         
@@ -14,46 +14,42 @@ fn log_runtime_error() {
                 return count;
             }
         }"#,
+        |_| {},
     );
 
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
+    let addr = src.contracts.last().unwrap();
 
-    runtime.invoke_contract(&addr, "decrement", vec![]);
+    src.invoke_contract(addr, "decrement", vec![]);
 
-    let logs = runtime.invoke_contract_expect_error(&addr, "decrement", vec![]);
+    let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
 
     assert!(logs[0].contains("runtime_error: math overflow in test.sol:5:17-27"));
 }
 
 #[test]
 fn print() {
-    let wasm = build_solidity(
+    let src = build_solidity(
         r#"contract Printer {
 
             function print() public {
                 print("Hello, World!");
             }
         }"#,
+        |_| {},
     );
 
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
+    let addr = src.contracts.last().unwrap();
 
-    runtime.invoke_contract(&addr, "print", vec![]);
+    src.invoke_contract(addr, "print", vec![]);
 
-    let logs = runtime.env.logs().all();
+    let logs = src.env.logs().all();
 
     assert!(logs[0].contains("Hello, World!"));
 }
 
 #[test]
 fn print_then_runtime_error() {
-    let wasm = build_solidity(
+    let src = build_solidity(
         r#"contract counter {
             uint64 public count = 1;
         
@@ -63,16 +59,14 @@ fn print_then_runtime_error() {
                 return count;
             }
         }"#,
+        |_| {},
     );
 
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
+    let addr = src.contracts.last().unwrap();
 
-    runtime.invoke_contract(&addr, "decrement", vec![]);
+    src.invoke_contract(addr, "decrement", vec![]);
 
-    let logs = runtime.invoke_contract_expect_error(&addr, "decrement", vec![]);
+    let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
 
     assert!(logs[0].contains("Second call will FAIL!"));
     assert!(logs[1].contains("runtime_error: math overflow in test.sol:6:17-27"));

--- a/tests/soroban_testcases/storage.rs
+++ b/tests/soroban_testcases/storage.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::build_solidity;
+use crate::{build_solidity, SorobanEnv};
 use soroban_sdk::{IntoVal, Val};
 
 #[test]
 fn counter() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract counter {
             uint64 public count = 10;
         
@@ -21,26 +21,29 @@ fn counter() {
         }"#,
     );
 
-    let addr = src.contracts.last().unwrap();
+    let mut runtime = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
+    let addr = runtime.register_contract(wasm, constructor_args);
 
-    let res = src.invoke_contract(addr, "count", vec![]);
-    let expected: Val = 10_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "count", vec![]);
+    let expected: Val = 10_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    src.invoke_contract(addr, "increment", vec![]);
-    let res = src.invoke_contract(addr, "count", vec![]);
-    let expected: Val = 11_u64.into_val(&src.env);
+    runtime.invoke_contract(&addr, "increment", vec![]);
+    let res = runtime.invoke_contract(&addr, "count", vec![]);
+    let expected: Val = 11_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    src.invoke_contract(addr, "decrement", vec![]);
-    let res = src.invoke_contract(addr, "count", vec![]);
-    let expected: Val = 10_u64.into_val(&src.env);
+    runtime.invoke_contract(&addr, "decrement", vec![]);
+    let res = runtime.invoke_contract(&addr, "count", vec![]);
+    let expected: Val = 10_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 }
 
 #[test]
 fn different_storage_types() {
-    let src = build_solidity(
+    let wasm = build_solidity(
         r#"contract sesa {
             
     uint64 public temporary sesa = 1;
@@ -64,60 +67,65 @@ fn different_storage_types() {
 }"#,
     );
 
-    let addr = src.contracts.last().unwrap();
+    let mut runtime = SorobanEnv::new();
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
+    let addr = runtime.register_contract(wasm, constructor_args);
 
-    let res = src.invoke_contract(addr, "sesa", vec![]);
-    let expected: Val = 1_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa", vec![]);
+    let expected: Val = 1_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa1", vec![]);
-    let expected: Val = 1_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa1", vec![]);
+    let expected: Val = 1_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa2", vec![]);
-    let expected: Val = 2_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa2", vec![]);
+    let expected: Val = 2_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa3", vec![]);
-    let expected: Val = 2_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa3", vec![]);
+    let expected: Val = 2_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    src.invoke_contract(addr, "inc", vec![]);
-    let res = src.invoke_contract(addr, "sesa", vec![]);
-    let expected: Val = 2_u64.into_val(&src.env);
+    runtime.invoke_contract(&addr, "inc", vec![]);
+    let res = runtime.invoke_contract(&addr, "sesa", vec![]);
+    let expected: Val = 2_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa1", vec![]);
-    let expected: Val = 2_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa1", vec![]);
+    let expected: Val = 2_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa2", vec![]);
-    let expected: Val = 3_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa2", vec![]);
+    let expected: Val = 3_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa3", vec![]);
-    let expected: Val = 3_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa3", vec![]);
+    let expected: Val = 3_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    src.invoke_contract(addr, "dec", vec![]);
-    let res = src.invoke_contract(addr, "sesa", vec![]);
-    let expected: Val = 1_u64.into_val(&src.env);
+    runtime.invoke_contract(&addr, "dec", vec![]);
+    let res = runtime.invoke_contract(&addr, "sesa", vec![]);
+    let expected: Val = 1_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa1", vec![]);
-    let expected: Val = 1_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa1", vec![]);
+    let expected: Val = 1_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa2", vec![]);
-    let expected: Val = 2_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa2", vec![]);
+    let expected: Val = 2_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = src.invoke_contract(addr, "sesa3", vec![]);
-    let expected: Val = 2_u64.into_val(&src.env);
+    let res = runtime.invoke_contract(&addr, "sesa3", vec![]);
+    let expected: Val = 2_u64.into_val(&runtime.env);
     assert!(expected.shallow_eq(&res));
 
-    let diags = src.compiler_diagnostics;
+    // FIXME: we need to figure out how to capture the compiler diagnostics but also
+    //        allow the test itself to define its own SorobanEnv (needed for ttl tests)
+    // let diags = runtime.compiler_diagnostics;
 
-    assert!(diags
-        .contains_message("storage type not specified for `sesa3`, defaulting to `persistent`"));
+    // assert!(diags
+    //     .contains_message("storage type not specified for `sesa3`, defaulting to `persistent`"));
 }

--- a/tests/soroban_testcases/storage.rs
+++ b/tests/soroban_testcases/storage.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{build_solidity, SorobanEnv};
+use crate::build_solidity;
 use soroban_sdk::{IntoVal, Val};
 
 #[test]
 fn counter() {
-    let wasm = build_solidity(
+    let src = build_solidity(
         r#"contract counter {
             uint64 public count = 10;
         
@@ -19,31 +19,29 @@ fn counter() {
                 return count;
             }
         }"#,
+        |_| {},
     );
 
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
+    let addr = src.contracts.last().unwrap();
 
-    let res = runtime.invoke_contract(&addr, "count", vec![]);
-    let expected: Val = 10_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "count", vec![]);
+    let expected: Val = 10_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    runtime.invoke_contract(&addr, "increment", vec![]);
-    let res = runtime.invoke_contract(&addr, "count", vec![]);
-    let expected: Val = 11_u64.into_val(&runtime.env);
+    src.invoke_contract(addr, "increment", vec![]);
+    let res = src.invoke_contract(addr, "count", vec![]);
+    let expected: Val = 11_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    runtime.invoke_contract(&addr, "decrement", vec![]);
-    let res = runtime.invoke_contract(&addr, "count", vec![]);
-    let expected: Val = 10_u64.into_val(&runtime.env);
+    src.invoke_contract(addr, "decrement", vec![]);
+    let res = src.invoke_contract(addr, "count", vec![]);
+    let expected: Val = 10_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 }
 
 #[test]
 fn different_storage_types() {
-    let wasm = build_solidity(
+    let src = build_solidity(
         r#"contract sesa {
             
     uint64 public temporary sesa = 1;
@@ -65,67 +63,63 @@ fn different_storage_types() {
         sesa3--;
     }
 }"#,
+        |_| {},
     );
 
-    let mut runtime = SorobanEnv::new();
-    // No constructor arguments
-    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
-    let addr = runtime.register_contract(wasm, constructor_args);
+    let addr = src.contracts.last().unwrap();
 
-    let res = runtime.invoke_contract(&addr, "sesa", vec![]);
-    let expected: Val = 1_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa", vec![]);
+    let expected: Val = 1_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa1", vec![]);
-    let expected: Val = 1_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa1", vec![]);
+    let expected: Val = 1_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa2", vec![]);
-    let expected: Val = 2_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa2", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa3", vec![]);
-    let expected: Val = 2_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa3", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    runtime.invoke_contract(&addr, "inc", vec![]);
-    let res = runtime.invoke_contract(&addr, "sesa", vec![]);
-    let expected: Val = 2_u64.into_val(&runtime.env);
+    src.invoke_contract(addr, "inc", vec![]);
+    let res = src.invoke_contract(addr, "sesa", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa1", vec![]);
-    let expected: Val = 2_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa1", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa2", vec![]);
-    let expected: Val = 3_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa2", vec![]);
+    let expected: Val = 3_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa3", vec![]);
-    let expected: Val = 3_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa3", vec![]);
+    let expected: Val = 3_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    runtime.invoke_contract(&addr, "dec", vec![]);
-    let res = runtime.invoke_contract(&addr, "sesa", vec![]);
-    let expected: Val = 1_u64.into_val(&runtime.env);
+    src.invoke_contract(addr, "dec", vec![]);
+    let res = src.invoke_contract(addr, "sesa", vec![]);
+    let expected: Val = 1_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa1", vec![]);
-    let expected: Val = 1_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa1", vec![]);
+    let expected: Val = 1_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa2", vec![]);
-    let expected: Val = 2_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa2", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    let res = runtime.invoke_contract(&addr, "sesa3", vec![]);
-    let expected: Val = 2_u64.into_val(&runtime.env);
+    let res = src.invoke_contract(addr, "sesa3", vec![]);
+    let expected: Val = 2_u64.into_val(&src.env);
     assert!(expected.shallow_eq(&res));
 
-    // FIXME: we need to figure out how to capture the compiler diagnostics but also
-    //        allow the test itself to define its own SorobanEnv (needed for ttl tests)
-    // let diags = runtime.compiler_diagnostics;
+    let diags = src.compiler_diagnostics;
 
-    // assert!(diags
-    //     .contains_message("storage type not specified for `sesa3`, defaulting to `persistent`"));
+    assert!(diags
+        .contains_message("storage type not specified for `sesa3`, defaulting to `persistent`"));
 }

--- a/tests/soroban_testcases/ttl.rs
+++ b/tests/soroban_testcases/ttl.rs
@@ -4,10 +4,6 @@ use crate::build_solidity;
 use soroban_sdk::testutils::storage::{Instance, Persistent, Temporary};
 use soroban_sdk::testutils::Ledger;
 
-/// This test is adapted from
-/// [Stellar Soroban Examples](https://github.com/stellar/soroban-examples/blob/f595fb5df06058ec0b9b829e9e4d0fe0513e0aa8/ttl).
-///
-/// It shows testing the TTL extension for persistent storage keys using the `extendPersistentTTL` built-in function
 #[test]
 fn ttl_basic_persistent() {
     let runtime = build_solidity(
@@ -145,4 +141,241 @@ fn ttl_instance_wrong() {
             });
         },
     );
+}
+
+#[test]
+fn ttl_instance_correct() {
+    let runtime = build_solidity(
+        r#"contract instance_counter {
+            /// Variable stored in instance storage
+            uint64 instance instanceCount = 3;
+
+            /// Extends the TTL for the instance storage to 10000 ledgers
+            /// if the current TTL is smaller than 2000 ledgers
+            function extend_instance_ttl() public view returns (int64) {
+                return extend_instance_ttl(2000, 10000);
+            }
+        }"#,
+        |env| {
+            env.env.ledger().with_mut(|li| {
+                // Current ledger sequence - the TTL is the number of
+                // ledgers from the `sequence_number` (exclusive) until
+                // the last ledger sequence where entry is still considered
+                // alive.
+                li.sequence_number = 100_000;
+                // Minimum TTL for persistent entries - new persistent (and instance)
+                // entries will have this TTL when created.
+                li.min_persistent_entry_ttl = 500;
+                // Minimum TTL for temporary entries - new temporary
+                // entries will have this TTL when created.
+                li.min_temp_entry_ttl = 100;
+                // Maximum TTL of any entry. Note, that entries can have their TTL
+                // extended indefinitely, but each extension can be at most
+                // `max_entry_ttl` ledger from the current `sequence_number`.
+                li.max_entry_ttl = 15000;
+            });
+        },
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+
+    // Initial TTL for instance storage
+    runtime.env.as_contract(addr, || {
+        assert_eq!(runtime.env.storage().instance().get_ttl(), 499);
+    });
+
+    // Extend instance TTL to 10000 ledgers
+    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.env.as_contract(addr, || {
+        assert_eq!(runtime.env.storage().instance().get_ttl(), 10000);
+    });
+}
+
+/// This test is adapted from
+/// [Stellar Soroban Examples](https://github.com/stellar/soroban-examples/blob/f595fb5df06058ec0b9b829e9e4d0fe0513e0aa8/ttl).
+#[test]
+fn ttl_combined() {
+    let runtime = build_solidity(
+        r#"
+        contract ttl_storage {
+            uint64 public persistent pCount = 11;
+            uint64 temporary tCount = 7;
+            uint64 instance iCount = 3;
+
+            function extend_persistent_ttl() public view returns (int64) {
+                return pCount.extendTtl(1000, 5000);
+            }
+
+            function extend_temp_ttl() public view returns (int64) {
+                return tCount.extendTtl(3000, 7000);
+            }
+
+            function extend_instance_ttl() public view returns (int64) {
+                return extend_instance_ttl(2000, 10000);
+            }
+        }"#,
+        |env| {
+            env.env.ledger().with_mut(|li| {
+                li.sequence_number = 100_000;
+                li.min_persistent_entry_ttl = 500;
+                li.min_temp_entry_ttl = 100;
+                li.max_entry_ttl = 15000;
+            });
+        },
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+
+    // Verify initial TTLs
+    runtime.env.as_contract(addr, || {
+        let pkey = runtime
+            .env
+            .storage()
+            .persistent()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        let tkey = runtime
+            .env
+            .storage()
+            .temporary()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().persistent().get_ttl(&pkey), 499);
+        assert_eq!(runtime.env.storage().instance().get_ttl(), 499);
+        assert_eq!(runtime.env.storage().temporary().get_ttl(&tkey), 99);
+    });
+
+    // Extend persistent storage TTL
+    runtime.invoke_contract(addr, "extend_persistent_ttl", vec![]);
+    runtime.env.as_contract(addr, || {
+        let pkey = runtime
+            .env
+            .storage()
+            .persistent()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().persistent().get_ttl(&pkey), 5000);
+    });
+
+    // Extend instance storage TTL
+    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.env.as_contract(addr, || {
+        assert_eq!(runtime.env.storage().instance().get_ttl(), 10000);
+    });
+
+    // Extend temporary storage TTL
+    runtime.invoke_contract(addr, "extend_temp_ttl", vec![]);
+    runtime.env.as_contract(addr, || {
+        let tkey = runtime
+            .env
+            .storage()
+            .temporary()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().temporary().get_ttl(&tkey), 7000);
+    });
+
+    // Bump ledger sequence by 5000
+    runtime.env.ledger().with_mut(|li| {
+        li.sequence_number = 105_000;
+    });
+
+    // Verify TTL after ledger increment
+    runtime.env.as_contract(addr, || {
+        let pkey = runtime
+            .env
+            .storage()
+            .persistent()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        let tkey = runtime
+            .env
+            .storage()
+            .temporary()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().persistent().get_ttl(&pkey), 0);
+        assert_eq!(runtime.env.storage().instance().get_ttl(), 5000);
+        assert_eq!(runtime.env.storage().temporary().get_ttl(&tkey), 2000);
+    });
+
+    // Re-extend all TTLs
+    runtime.invoke_contract(addr, "extend_persistent_ttl", vec![]);
+    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.invoke_contract(addr, "extend_temp_ttl", vec![]);
+
+    // Final TTL verification
+    runtime.env.as_contract(addr, || {
+        let pkey = runtime
+            .env
+            .storage()
+            .persistent()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        let tkey = runtime
+            .env
+            .storage()
+            .temporary()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().persistent().get_ttl(&pkey), 5000);
+        assert_eq!(runtime.env.storage().instance().get_ttl(), 5000); // Threshold not met, remains the same
+        assert_eq!(runtime.env.storage().temporary().get_ttl(&tkey), 7000);
+    });
+}
+
+#[test]
+#[should_panic(expected = "[testing-only] Accessed contract instance key that has been archived.")]
+fn test_persistent_entry_archival() {
+    let runtime = build_solidity(
+        r#"
+        contract persistent_cleanup {
+            uint64 public persistent pCount = 11;
+
+            function extend_persistent_ttl() public view returns (int64) {
+                return pCount.extendTtl(1000, 10000);
+            }
+
+            function extend_instance_ttl() public view returns (int64) {
+                return extend_instance_ttl(2000, 10000);
+            }
+        }"#,
+        |env| {
+            env.env.ledger().with_mut(|li| {
+                li.sequence_number = 100_000;
+                li.min_persistent_entry_ttl = 500;
+                li.min_temp_entry_ttl = 100;
+                li.max_entry_ttl = 15000;
+            });
+        },
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+
+    // Extend instance TTL
+    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+
+    // Bump ledger sequence by 10001 (one past persistent TTL)
+    runtime.env.ledger().with_mut(|li| {
+        li.sequence_number = 110_001;
+    });
+
+    // This should panic as the persistent entry is archived
+    runtime.invoke_contract(addr, "extend_persistent_ttl", vec![]);
 }

--- a/tests/soroban_testcases/ttl.rs
+++ b/tests/soroban_testcases/ttl.rs
@@ -131,7 +131,7 @@ fn ttl_instance_wrong() {
         r#"contract instance_counter {
             uint64 instance instanceCount = 3;
             
-            function extend_instance_ttl() public view returns (int64) {
+            function extendInstanceTtl() public view returns (int64) {
                 return instanceCount.extendTtl(700, 3000);
             }
         }"#,
@@ -152,8 +152,8 @@ fn ttl_instance_correct() {
 
             /// Extends the TTL for the instance storage to 10000 ledgers
             /// if the current TTL is smaller than 2000 ledgers
-            function extend_instance_ttl() public view returns (int64) {
-                return extend_instance_ttl(2000, 10000);
+            function extendInstanceTtl() public view returns (int64) {
+                return extendInstanceTtl(2000, 10000);
             }
         }"#,
         |env| {
@@ -185,7 +185,7 @@ fn ttl_instance_correct() {
     });
 
     // Extend instance TTL to 10000 ledgers
-    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.invoke_contract(addr, "extendInstanceTtl", vec![]);
     runtime.env.as_contract(addr, || {
         assert_eq!(runtime.env.storage().instance().get_ttl(), 10000);
     });
@@ -210,8 +210,8 @@ fn ttl_combined() {
                 return tCount.extendTtl(3000, 7000);
             }
 
-            function extend_instance_ttl() public view returns (int64) {
-                return extend_instance_ttl(2000, 10000);
+            function extendInstanceTtl() public view returns (int64) {
+                return extendInstanceTtl(2000, 10000);
             }
         }"#,
         |env| {
@@ -264,7 +264,7 @@ fn ttl_combined() {
     });
 
     // Extend instance storage TTL
-    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.invoke_contract(addr, "extendInstanceTtl", vec![]);
     runtime.env.as_contract(addr, || {
         assert_eq!(runtime.env.storage().instance().get_ttl(), 10000);
     });
@@ -313,7 +313,7 @@ fn ttl_combined() {
 
     // Re-extend all TTLs
     runtime.invoke_contract(addr, "extend_persistent_ttl", vec![]);
-    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.invoke_contract(addr, "extendInstanceTtl", vec![]);
     runtime.invoke_contract(addr, "extend_temp_ttl", vec![]);
 
     // Final TTL verification
@@ -352,8 +352,8 @@ fn test_persistent_entry_archival() {
                 return pCount.extendTtl(1000, 10000);
             }
 
-            function extend_instance_ttl() public view returns (int64) {
-                return extend_instance_ttl(2000, 10000);
+            function extendInstanceTtl() public view returns (int64) {
+                return extendInstanceTtl(2000, 10000);
             }
         }"#,
         |env| {
@@ -369,7 +369,7 @@ fn test_persistent_entry_archival() {
     let addr = runtime.contracts.last().unwrap();
 
     // Extend instance TTL
-    runtime.invoke_contract(addr, "extend_instance_ttl", vec![]);
+    runtime.invoke_contract(addr, "extendInstanceTtl", vec![]);
 
     // Bump ledger sequence by 10001 (one past persistent TTL)
     runtime.env.ledger().with_mut(|li| {

--- a/tests/soroban_testcases/ttl.rs
+++ b/tests/soroban_testcases/ttl.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{build_solidity, SorobanEnv};
+use soroban_sdk::testutils::storage::Persistent;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::Val;
+
+/// This test is adapted from
+/// [Stellar Soroban Examples](https://github.com/stellar/soroban-examples/blob/f595fb5df06058ec0b9b829e9e4d0fe0513e0aa8/ttl).
+///
+/// It shows testing the TTL extension for persistent storage keys using the `extendPersistentTTL` built-in function
+#[test]
+fn ttl_basic() {
+    let mut runtime = SorobanEnv::new();
+
+    runtime.env.ledger().with_mut(|li| {
+        // Current ledger sequence - the TTL is the number of
+        // ledgers from the `sequence_number` (exclusive) until
+        // the last ledger sequence where entry is still considered
+        // alive.
+        li.sequence_number = 100_000;
+        // Minimum TTL for persistent entries - new persistent (and instance)
+        // entries will have this TTL when created.
+        li.min_persistent_entry_ttl = 500;
+    });
+
+    let wasm = build_solidity(
+        r#"contract counter {
+            /// Variable to track the count. Stored in persistent storage
+            uint64 public persistent count = 11;
+
+            /// Extends the TTL for the `count` persistent key to 5000 ledgers
+            /// if the current TTL is smaller than 1000 ledgers
+            function extend_ttl() public view returns (int64) {
+                return count.extendPersistentTtl(1000, 5000);
+            }
+        }"#,
+    );
+
+    // No constructor arguments
+    let constructor_args: soroban_sdk::Vec<Val> = soroban_sdk::Vec::new(&runtime.env);
+    let addr = runtime.register_contract(wasm, constructor_args);
+
+    // initial TTL
+    runtime.env.as_contract(&addr, || {
+        // There is only one key in the persistent storage
+        let key = runtime
+            .env
+            .storage()
+            .persistent()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().persistent().get_ttl(&key), 499);
+    });
+
+    // Extend persistent entry TTL to 5000 ledgers - now it is 5000.
+    runtime.invoke_contract(&addr, "extend_ttl", vec![]);
+
+    runtime.env.as_contract(&addr, || {
+        // There is only one key in the persistent storage
+        let key = runtime
+            .env
+            .storage()
+            .persistent()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().persistent().get_ttl(&key), 5000);
+    });
+}

--- a/tests/soroban_testcases/ttl.rs
+++ b/tests/soroban_testcases/ttl.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::build_solidity;
-use soroban_sdk::testutils::storage::Persistent;
+use soroban_sdk::testutils::storage::{Instance, Persistent, Temporary};
 use soroban_sdk::testutils::Ledger;
 
 /// This test is adapted from
@@ -9,7 +9,7 @@ use soroban_sdk::testutils::Ledger;
 ///
 /// It shows testing the TTL extension for persistent storage keys using the `extendPersistentTTL` built-in function
 #[test]
-fn ttl_basic() {
+fn ttl_basic_persistent() {
     let runtime = build_solidity(
         r#"contract counter {
             /// Variable to track the count. Stored in persistent storage
@@ -66,4 +66,83 @@ fn ttl_basic() {
             .unwrap();
         assert_eq!(runtime.env.storage().persistent().get_ttl(&key), 5000);
     });
+}
+
+#[test]
+fn ttl_basic_temporary() {
+    let runtime = build_solidity(
+        r#"contract temp_counter {
+            /// Variable stored in temporary storage
+            uint64 temporary tempCount = 7;
+
+            /// Extend the temporary entry TTL to become at least 7000 ledgers,
+            /// when its TTL is smaller than 3000 ledgers.
+            function extend_temp_ttl() public view returns (int64) {
+                return tempCount.extendTtl(3000, 7000);
+            }
+        }"#,
+        |env| {
+            env.env.ledger().with_mut(|li| {
+                // Current ledger sequence - the TTL is the number of
+                // ledgers from the `sequence_number` (exclusive) until
+                // the last ledger sequence where entry is still considered
+                // alive.
+                li.sequence_number = 100_000;
+                // Minimum TTL for temporary entries - new temporary
+                // entries will have this TTL when created.
+                li.min_temp_entry_ttl = 100;
+            });
+        },
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+
+    // initial TTL
+    runtime.env.as_contract(addr, || {
+        let key = runtime
+            .env
+            .storage()
+            .temporary()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().temporary().get_ttl(&key), 99);
+    });
+
+    // Extend temporary entry TTL to 7000 ledgers - now it is 7000.
+    runtime.invoke_contract(addr, "extend_temp_ttl", vec![]);
+
+    runtime.env.as_contract(addr, || {
+        let key = runtime
+            .env
+            .storage()
+            .temporary()
+            .all()
+            .keys()
+            .first()
+            .unwrap();
+        assert_eq!(runtime.env.storage().temporary().get_ttl(&key), 7000);
+    });
+}
+
+#[test]
+#[should_panic(
+    expected = "Calling extendTtl() on instance storage is not allowed. Use `extendInstanceTtl()` instead."
+)]
+fn ttl_instance_wrong() {
+    let _runtime = build_solidity(
+        r#"contract instance_counter {
+            uint64 instance instanceCount = 3;
+            
+            function extend_instance_ttl() public view returns (int64) {
+                return instanceCount.extendTtl(700, 3000);
+            }
+        }"#,
+        |env| {
+            env.env.ledger().with_mut(|li| {
+                li.sequence_number = 100_000;
+            });
+        },
+    );
 }

--- a/tests/soroban_testcases/ttl.rs
+++ b/tests/soroban_testcases/ttl.rs
@@ -38,7 +38,7 @@ fn ttl_basic() {
     let addr = runtime.contracts.last().unwrap();
 
     // initial TTL
-    runtime.env.as_contract(&addr, || {
+    runtime.env.as_contract(addr, || {
         // There is only one key in the persistent storage
         let key = runtime
             .env
@@ -52,9 +52,9 @@ fn ttl_basic() {
     });
 
     // Extend persistent entry TTL to 5000 ledgers - now it is 5000.
-    runtime.invoke_contract(&addr, "extend_ttl", vec![]);
+    runtime.invoke_contract(addr, "extend_ttl", vec![]);
 
-    runtime.env.as_contract(&addr, || {
+    runtime.env.as_contract(addr, || {
         // There is only one key in the persistent storage
         let key = runtime
             .env

--- a/tests/soroban_testcases/ttl.rs
+++ b/tests/soroban_testcases/ttl.rs
@@ -18,7 +18,7 @@ fn ttl_basic() {
             /// Extends the TTL for the `count` persistent key to 5000 ledgers
             /// if the current TTL is smaller than 1000 ledgers
             function extend_ttl() public view returns (int64) {
-                return count.extendPersistentTtl(1000, 5000);
+                return count.extendTtl(1000, 5000);
             }
         }"#,
         |env| {


### PR DESCRIPTION
This PR adds support for `extendPersistentTtl()` method in Soroban, along with a test and documentation. Also, the Soroban testing infrastructure has been refactored to allow more flexible environment manipulation.

[Documentation for `extend_ttl`](https://developers.stellar.org/docs/build/smart-contracts/getting-started/storing-data#managing-contract-data-ttls-with-extend_ttl)
Fixes #1669

#### Changes 
- Added support for `extendPersistentTtl` as a method on `uint64` for the Soroban target.
    - In the Soroban SDK, `extend_ttl` is a generic function (`IntoVal<Env, Val>`)
```rust
pub fn extend_ttl<K>(&self, key: &K, threshold: u32, extend_to: u32)
where
    K: IntoVal<Env, Val>,
```
but Solidity does not support that, so it's implemented as a method instead.
- One assertion in the `different_storage_types` test is affected due to changes in diagnostic capture. A follow-up PR will address this.