### PR TITLE
Fix two infinite loops in codegen

### DIFF
--- a/tests/codegen_testcases/solidity/do_while_break_2.sol
+++ b/tests/codegen_testcases/solidity/do_while_break_2.sol
@@ -1,0 +1,24 @@
+// RUN: --target polkadot --emit cfg
+
+contract C {
+	// CHECK: C::function::f
+	function f() public pure {
+		uint a = 0;
+		while (true) {
+			do {
+				break;
+				a = 2;
+			} while (true);
+			a = 1;
+			break;
+		}
+		assert(a == 1);
+	}
+}
+// ====
+// SMTEngine: all
+// SMTSolvers: z3
+// ----
+// Warning 5740: (95-100): Unreachable code.
+// Warning 5740: (114-118): Unreachable code.
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/tests/codegen_testcases/solidity/do_while_break_2_fail.sol
+++ b/tests/codegen_testcases/solidity/do_while_break_2_fail.sol
@@ -1,0 +1,24 @@
+// RUN: --target polkadot --emit cfg
+
+contract C {
+	// CHECK: C::function::f
+	function f() public pure {
+		uint a = 0;
+		while (true) {
+			do {
+				break;
+				a = 2;
+			} while (true);
+			a = 1;
+			break;
+		}
+		assert(a == 2);
+	}
+}
+// ====
+// SMTEngine: all
+// SMTSolvers: z3
+// ----
+// Warning 5740: (95-100): Unreachable code.
+// Warning 5740: (114-118): Unreachable code.
+// Warning 6328: (147-161): CHC: Assertion violation happens here.\nCounterexample:\n\na = 1\n\nTransaction trace:\nC.constructor()\nC.f()


### PR DESCRIPTION
This PR fixes infinite lops in the reaching definitions and dead storage code.

The two added test files are based on ones from Solidity:
- https://github.com/ethereum/solidity/blob/develop/test/libsolidity/smtCheckerTests/loops/do_while_break_2.sol
- https://github.com/ethereum/solidity/blob/develop/test/libsolidity/smtCheckerTests/loops/do_while_break_2_fail.sol

If you add `dbg!(block_no)` between the next two lines and run Solang on either of the test files, you will find that a block is visited repeatedly: https://github.com/hyperledger-solang/solang/blob/279ee911260d74c78acace41d753c5376a7e942e/src/codegen/reaching_definitions.rs#L56-L57

If you fix that infinite loop and add `dbg!(block_no)` between the next two lines, you will again find that a block is visited repeatedly: https://github.com/hyperledger-solang/solang/blob/279ee911260d74c78acace41d753c5376a7e942e/src/codegen/dead_storage.rs#L109-L110

In both cases, the problem appears to be that edges are added to the `blocks_todo` queue unconditionally.

My understanding of these algorithms is that they try to iterate to a fixpoint. Hence, I changed each loop so that:
- a flag records whether a _state change_ has occurred
- at the end of each loop iteration, the edge is added to the queue only if the flag is set

Furthermore, I analyzed each loop to try to determine what constitutes a state change. On this point, I invite scrutiny.

Nits are welcome on anything, though.