### PR TITLE
Fix build and 1.86.0 clippies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -41,7 +41,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ make
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-linux-arm64.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-linux-arm64.tar.xz
     - name: Extract LLVM
@@ -74,7 +74,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm16.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
       with:
         components: clippy
     - name: Build
@@ -97,7 +97,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-mac-arm.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -124,7 +124,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Get LLVM
       run: wget -q -O llvm16.0-mac-intel.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,24 +10,6 @@ env:
   LLVM_PROFILE_FILE: ${{ github.workspace }}/target/solang-%p-%10m.profraw
 
 jobs:
-  repolinter:
-    name: Repolinter
-    runs-on: solang-ubuntu-latest
-    # spdx runs on python 3.10 but not any later versions
-    container: ubuntu:22.04
-    steps:
-      - name: Install Python and npm
-        run: |
-          apt-get update
-          apt-get install -y python3 git npm
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Run repolinter
-        run: npx repolinter --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/master/repo_structure/repolint.json
-      - uses: enarx/spdx@master
-        with:
-          licenses: Apache-2.0
-
   docs:
     name: Docs
     runs-on: solang-ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.81.0
+        toolchain: 1.82.0
         components: |
           llvm-tools
           clippy
@@ -126,7 +126,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ make
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-linux-arm64.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-linux-arm64.tar.xz
     - name: Extract LLVM
@@ -159,7 +159,7 @@ jobs:
     # Use C:\ as D:\ might run out of space
     - name: "Use C: for rust temporary files"
       run: echo "CARGO_TARGET_DIR=C:\target" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
       with:
         components: clippy
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
@@ -185,7 +185,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Get LLVM
       run: curl -sSL --output llvm16.0-mac-arm.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -211,7 +211,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Get LLVM
       run: wget -q -O llvm16.0-mac-intel.tar.xz https://github.com/hyperledger-solang/solang-llvm/releases/download/llvm16-0/llvm16.0-mac-intel.tar.xz
     - name: Extract LLVM
@@ -273,7 +273,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - name: Setup yarn
       run: npm install -g yarn
     - uses: actions/download-artifact@v4.1.8
@@ -324,7 +324,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
       with:
         target: wasm32-unknown-unknown
     - uses: actions/download-artifact@v4.1.8
@@ -371,7 +371,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
     - uses: actions/download-artifact@v4.1.8
       with:
         name: solang-linux-x86-64
@@ -548,7 +548,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.82.0
           components: llvm-tools
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 build = "build.rs"
 description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "polkadot", "substrate" ]
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 edition = "2021"
 exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode", "/testdata" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . src
 WORKDIR /src/stdlib/
 RUN make
 
-RUN rustup default 1.81.0
+RUN rustup default 1.82.0
 
 WORKDIR /src
 RUN cargo build --release

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -89,7 +89,7 @@ Option 5: Build Solang from source
 
 In order to build Solang from source, you will need:
 
-* Rust version 1.81.0 or higher
+* Rust version 1.82.0 or higher
 * A C++ compiler with support for C++17
 * A build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
 

--- a/fmt/src/buffer.rs
+++ b/fmt/src/buffer.rs
@@ -91,7 +91,7 @@ impl<W> FormatBuffer<W> {
     /// Indent the buffer by delta
     pub fn indent(&mut self, delta: usize) {
         self.indents
-            .extend(std::iter::repeat(IndentGroup::default()).take(delta));
+            .extend(std::iter::repeat_n(IndentGroup::default(), delta));
     }
 
     /// Dedent the buffer by delta

--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -93,7 +93,7 @@ impl CommentWithMetadata {
             return Self::new(
                 comment,
                 CommentPosition::Prefix,
-                last_line.map_or(true, str::is_empty),
+                last_line.is_none_or(str::is_empty),
                 indent_len,
             );
         }

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -1532,7 +1532,7 @@ impl FunctionDefinition {
     /// Returns `true` if the function body is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.body.as_ref().map_or(true, Statement::is_empty)
+        self.body.as_ref().is_none_or(Statement::is_empty)
     }
 
     /// Sorts the function attributes.

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -1640,8 +1640,8 @@ impl Type {
         match self {
             Type::Contract(_) | Type::Address(_) => ns.address_length as u8,
             Type::Bool => 1,
-            Type::Int(n) => ((*n + 7) / 8) as u8,
-            Type::Uint(n) => ((*n + 7) / 8) as u8,
+            Type::Int(n) => (*n).div_ceil(8) as u8,
+            Type::Uint(n) => (*n).div_ceil(8) as u8,
             Type::Rational => unreachable!(),
             Type::Bytes(n) => *n,
             Type::Enum(n) => ns.enums[*n].ty.bytes(ns),

--- a/tests/lir_tests/convert_lir.rs
+++ b/tests/lir_tests/convert_lir.rs
@@ -52,7 +52,7 @@ fn assert_lir_str_eq_by_name(src: &str, cfg_name: &str, expected: &str, target: 
         .cfg
         .iter()
         .filter(|cfg| cfg.name == cfg_name)
-        .last()
+        .next_back()
         .unwrap();
 
     let converter = Converter::new(&ns, cfg);


### PR DESCRIPTION
- Fix rust 1.86.0 clippies
- Build with rust 1.82.0 - required by dependencies
- Remove repolinter as it is not working and no longer required by hyperledger 