### PR TITLE
Fix a small typo affecting `Expression::GetRef`

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -983,7 +983,7 @@ impl ControlFlowGraph {
                 )
             }
             Expression::GetRef { expr, .. } => {
-                format!("(deref {}", self.expr_to_string(contract, ns, expr))
+                format!("(deref {})", self.expr_to_string(contract, ns, expr))
             }
             Expression::VectorData { pointer } => {
                 format!("pointer pos {}", self.expr_to_string(contract, ns, pointer))


### PR DESCRIPTION
From what I can tell, this change affects no tests.