### PR TITLE
Fix: propagate strict_soroban_types and re-enable soroban_testcases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,14 @@ pub fn parse_and_resolve_with_options(
     filename: &OsStr,
     resolver: &mut FileResolver,
     target: Target,
-    _options: Option<&codegen::Options>,
+    options: Option<&codegen::Options>,
 ) -> sema::ast::Namespace {
     let mut ns = sema::ast::Namespace::new(target);
+
+    // Propagate selected options into the namespace prior to sema
+    if let Some(opts) = options {
+        ns.strict_soroban_types = opts.strict_soroban_types;
+    }
 
     match resolver.resolve_file(None, filename) {
         Err(message) => {

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "soroban")]
+pub mod soroban_testcases;
+
 use solang::codegen::Options;
 use solang::file_resolver::FileResolver;
 use solang::sema::ast::Namespace;

--- a/tests/soroban_testcases/integer_width_warnings.rs
+++ b/tests/soroban_testcases/integer_width_warnings.rs
@@ -39,16 +39,23 @@ fn test_warning_for_int56_without_strict() {
             return int64(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, false);
-    
+
     // Should have a warning about int56 being rounded to int64
-    let warnings: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Warning).collect();
+    let warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Warning)
+        .collect();
     assert!(!warnings.is_empty(), "Expected warnings for int56 rounding");
-    
+
     let warning_messages: Vec<_> = warnings.iter().map(|w| w.message.as_str()).collect();
-    assert!(warning_messages.iter().any(|msg| msg.contains("int56") && msg.contains("int64")), 
-            "Expected warning about int56 being rounded to int64");
+    assert!(
+        warning_messages
+            .iter()
+            .any(|msg| msg.contains("int56") && msg.contains("int64")),
+        "Expected warning about int56 being rounded to int64"
+    );
 }
 
 #[test]
@@ -58,16 +65,26 @@ fn test_warning_for_uint56_without_strict() {
             return uint64(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, false);
-    
+
     // Should have a warning about uint56 being rounded to uint64
-    let warnings: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Warning).collect();
-    assert!(!warnings.is_empty(), "Expected warnings for uint56 rounding");
-    
+    let warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Warning)
+        .collect();
+    assert!(
+        !warnings.is_empty(),
+        "Expected warnings for uint56 rounding"
+    );
+
     let warning_messages: Vec<_> = warnings.iter().map(|w| w.message.as_str()).collect();
-    assert!(warning_messages.iter().any(|msg| msg.contains("uint56") && msg.contains("uint64")), 
-            "Expected warning about uint56 being rounded to uint64");
+    assert!(
+        warning_messages
+            .iter()
+            .any(|msg| msg.contains("uint56") && msg.contains("uint64")),
+        "Expected warning about uint56 being rounded to uint64"
+    );
 }
 
 #[test]
@@ -77,16 +94,23 @@ fn test_warning_for_int96_without_strict() {
             return int128(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, false);
-    
+
     // Should have a warning about int96 being rounded to int128
-    let warnings: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Warning).collect();
+    let warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Warning)
+        .collect();
     assert!(!warnings.is_empty(), "Expected warnings for int96 rounding");
-    
+
     let warning_messages: Vec<_> = warnings.iter().map(|w| w.message.as_str()).collect();
-    assert!(warning_messages.iter().any(|msg| msg.contains("int96") && msg.contains("int128")), 
-            "Expected warning about int96 being rounded to int128");
+    assert!(
+        warning_messages
+            .iter()
+            .any(|msg| msg.contains("int96") && msg.contains("int128")),
+        "Expected warning about int96 being rounded to int128"
+    );
 }
 
 #[test]
@@ -96,16 +120,26 @@ fn test_warning_for_uint96_without_strict() {
             return uint128(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, false);
-    
+
     // Should have a warning about uint96 being rounded to uint128
-    let warnings: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Warning).collect();
-    assert!(!warnings.is_empty(), "Expected warnings for uint96 rounding");
-    
+    let warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Warning)
+        .collect();
+    assert!(
+        !warnings.is_empty(),
+        "Expected warnings for uint96 rounding"
+    );
+
     let warning_messages: Vec<_> = warnings.iter().map(|w| w.message.as_str()).collect();
-    assert!(warning_messages.iter().any(|msg| msg.contains("uint96") && msg.contains("uint128")), 
-            "Expected warning about uint96 being rounded to uint128");
+    assert!(
+        warning_messages
+            .iter()
+            .any(|msg| msg.contains("uint96") && msg.contains("uint128")),
+        "Expected warning about uint96 being rounded to uint128"
+    );
 }
 
 #[test]
@@ -115,16 +149,26 @@ fn test_error_for_int56_with_strict() {
             return int64(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, true);
-    
+
     // Should have an error about int56 being rounded to int64
-    let errors: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Error).collect();
-    assert!(!errors.is_empty(), "Expected errors for int56 rounding with strict mode");
-    
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Error)
+        .collect();
+    assert!(
+        !errors.is_empty(),
+        "Expected errors for int56 rounding with strict mode"
+    );
+
     let error_messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-    assert!(error_messages.iter().any(|msg| msg.contains("int56") && msg.contains("int64")), 
-            "Expected error about int56 being rounded to int64");
+    assert!(
+        error_messages
+            .iter()
+            .any(|msg| msg.contains("int56") && msg.contains("int64")),
+        "Expected error about int56 being rounded to int64"
+    );
 }
 
 #[test]
@@ -134,16 +178,26 @@ fn test_error_for_uint56_with_strict() {
             return uint64(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, true);
-    
+
     // Should have an error about uint56 being rounded to uint64
-    let errors: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Error).collect();
-    assert!(!errors.is_empty(), "Expected errors for uint56 rounding with strict mode");
-    
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Error)
+        .collect();
+    assert!(
+        !errors.is_empty(),
+        "Expected errors for uint56 rounding with strict mode"
+    );
+
     let error_messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-    assert!(error_messages.iter().any(|msg| msg.contains("uint56") && msg.contains("uint64")), 
-            "Expected error about uint56 being rounded to uint64");
+    assert!(
+        error_messages
+            .iter()
+            .any(|msg| msg.contains("uint56") && msg.contains("uint64")),
+        "Expected error about uint56 being rounded to uint64"
+    );
 }
 
 #[test]
@@ -153,16 +207,26 @@ fn test_error_for_int96_with_strict() {
             return int128(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, true);
-    
+
     // Should have an error about int96 being rounded to int128
-    let errors: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Error).collect();
-    assert!(!errors.is_empty(), "Expected errors for int96 rounding with strict mode");
-    
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Error)
+        .collect();
+    assert!(
+        !errors.is_empty(),
+        "Expected errors for int96 rounding with strict mode"
+    );
+
     let error_messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-    assert!(error_messages.iter().any(|msg| msg.contains("int96") && msg.contains("int128")), 
-            "Expected error about int96 being rounded to int128");
+    assert!(
+        error_messages
+            .iter()
+            .any(|msg| msg.contains("int96") && msg.contains("int128")),
+        "Expected error about int96 being rounded to int128"
+    );
 }
 
 #[test]
@@ -172,16 +236,26 @@ fn test_error_for_uint96_with_strict() {
             return uint128(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, true);
-    
+
     // Should have an error about uint96 being rounded to uint128
-    let errors: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Error).collect();
-    assert!(!errors.is_empty(), "Expected errors for uint96 rounding with strict mode");
-    
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Error)
+        .collect();
+    assert!(
+        !errors.is_empty(),
+        "Expected errors for uint96 rounding with strict mode"
+    );
+
     let error_messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-    assert!(error_messages.iter().any(|msg| msg.contains("uint96") && msg.contains("uint128")), 
-            "Expected error about uint96 being rounded to uint128");
+    assert!(
+        error_messages
+            .iter()
+            .any(|msg| msg.contains("uint96") && msg.contains("uint128")),
+        "Expected error about uint96 being rounded to uint128"
+    );
 }
 
 #[test]
@@ -191,16 +265,26 @@ fn test_error_for_int200_with_strict() {
             return int256(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, true);
-    
+
     // Should have an error about int200 being rounded to int256
-    let errors: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Error).collect();
-    assert!(!errors.is_empty(), "Expected errors for int200 rounding with strict mode");
-    
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Error)
+        .collect();
+    assert!(
+        !errors.is_empty(),
+        "Expected errors for int200 rounding with strict mode"
+    );
+
     let error_messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-    assert!(error_messages.iter().any(|msg| msg.contains("int200") && msg.contains("int256")), 
-            "Expected error about int200 being rounded to int256");
+    assert!(
+        error_messages
+            .iter()
+            .any(|msg| msg.contains("int200") && msg.contains("int256")),
+        "Expected error about int200 being rounded to int256"
+    );
 }
 
 #[test]
@@ -210,14 +294,24 @@ fn test_error_for_uint200_with_strict() {
             return uint256(a);
         }
     }"#;
-    
+
     let diagnostics = build_with_strict_soroban_types(src, true);
-    
+
     // Should have an error about uint200 being rounded to uint256
-    let errors: Vec<_> = diagnostics.iter().filter(|d| d.level == solang_parser::diagnostics::Level::Error).collect();
-    assert!(!errors.is_empty(), "Expected errors for uint200 rounding with strict mode");
-    
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.level == solang_parser::diagnostics::Level::Error)
+        .collect();
+    assert!(
+        !errors.is_empty(),
+        "Expected errors for uint200 rounding with strict mode"
+    );
+
     let error_messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-    assert!(error_messages.iter().any(|msg| msg.contains("uint200") && msg.contains("uint256")), 
-            "Expected error about uint200 being rounded to uint256");
+    assert!(
+        error_messages
+            .iter()
+            .any(|msg| msg.contains("uint200") && msg.contains("uint256")),
+        "Expected error about uint200 being rounded to uint256"
+    );
 }


### PR DESCRIPTION
1. Propagate Options.strict_soroban_types into Namespace so Soroban integer-width rounding diagnostics are emitted correctly.
2. Re-enable tests/soroban.rs module soroban_testcases under #[cfg(feature = "soroban")].
