### PR TITLE
poc(miden): support a counter contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 build = "build.rs"
 description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "polkadot", "substrate" ]
-rust-version = "1.85.0"
+rust-version = "1.87"
 edition = "2021"
 exclude = [ "/.*", "/docs", "/solana-library", "/tests", "/integration", "/vscode", "/testdata" ]
 
@@ -72,6 +72,7 @@ solang-forge-fmt = { version = "0.2.0", optional = true }
 # build to work.
 ethers-core = { version = "2.0.10", optional = true }
 soroban-sdk = { version = "23.0.0-rc.2.2", features = ["testutils"], optional = true }
+miden-vm = "=0.16.0"
 
 [dev-dependencies]
 num-derive = "0.4"

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -273,7 +273,7 @@ pub struct TargetArg {
 
 #[derive(Args, Deserialize, Debug, PartialEq)]
 pub struct CompileTargetArg {
-    #[arg(name = "TARGET", long = "target", value_parser = ["solana", "polkadot", "evm", "soroban"], help = "Target to build for [possible values: solana, polkadot]", num_args = 1, hide_possible_values = true)]
+    #[arg(name = "TARGET", long = "target", value_parser = ["solana", "polkadot", "evm", "soroban", "miden"], help = "Target to build for [possible values: solana, polkadot]", num_args = 1, hide_possible_values = true)]
     pub name: Option<String>,
 
     #[arg(name = "ADDRESS_LENGTH", help = "Address length on the Polkadot Parachain", long = "address-length", num_args = 1, value_parser = value_parser!(u64).range(4..1024))]
@@ -469,6 +469,7 @@ pub(crate) fn target_arg<T: TargetArgTrait>(target_arg: &T) -> Target {
         },
         "evm" => solang::Target::EVM,
         "soroban" => solang::Target::Soroban,
+        "miden" => solang::Target::Miden,
         _ => unreachable!(),
     };
 

--- a/src/codegen/dispatch/mod.rs
+++ b/src/codegen/dispatch/mod.rs
@@ -19,5 +19,6 @@ pub(super) fn function_dispatch(
             polkadot::function_dispatch(contract_no, all_cfg, ns, opt)
         }
         Target::Soroban => soroban::function_dispatch(contract_no, all_cfg, ns, opt),
+        Target::Miden => Vec::new(),
     }
 }

--- a/src/codegen/events/mod.rs
+++ b/src/codegen/events/mod.rs
@@ -51,6 +51,6 @@ pub(super) fn new_event_emitter<'a>(
             event_no,
         }),
 
-        Target::Soroban => todo!(),
+        Target::Soroban | Target::Miden => todo!(),
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -950,6 +950,18 @@ impl RetrieveType for Expression {
 }
 
 impl Expression {
+    /// POC(miden): Convert expression to miden expression string
+    /// This is a very naive implementation and only handles a few cases.
+    pub fn to_miden_expr(self) -> String {
+        match self {
+            Expression::NumberLiteral { value, .. } => value.to_string(),
+            _ => {
+                // For unsupported expressions, return a placeholder
+                "UNSUPPORTED_EXPR".to_string()
+            }
+        }
+    }
+
     /// Increment an expression by some value.
     pub(crate) fn add_u32(self, other: Expression) -> Self {
         Expression::Add {

--- a/src/codegen/statements/mod.rs
+++ b/src/codegen/statements/mod.rs
@@ -851,6 +851,9 @@ fn returns(
         .map(|(left, right)| try_load_and_cast(&right.loc(), &right, &left.ty, ns, cfg, vartab))
         .collect();
 
+    //POC(Miden): for miden, the return instr returns the data on the stack
+    cfg.push_miden_instr("exec.sys::truncate_stack".to_string());
+
     cfg.add(vartab, Instr::Return { value: cast_values });
 }
 

--- a/src/emit/miden/mod.rs
+++ b/src/emit/miden/mod.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::codegen::cfg::Instr;
+use crate::codegen::Expression;
+use crate::codegen::{cfg::ControlFlowGraph, Options};
+
+use crate::{emit::Binary, sema::ast};
+use inkwell::{context::Context, module::Module};
+pub(super) mod target;
+
+pub struct Midentarget;
+
+impl Midentarget {
+    pub fn build<'a>(
+        context: &'a Context,
+        std_lib: &Module<'a>,
+        contract: &'a ast::Contract,
+        ns: &'a ast::Namespace,
+        opt: &'a Options,
+        _contract_no: usize,
+    ) -> Binary<'a> {
+        let filename = ns.files[contract.loc.file_no()].file_name();
+        let mut bin = Binary::new(
+            context,
+            ns,
+            &contract.id.name,
+            &filename,
+            opt,
+            std_lib,
+            None,
+        );
+
+        // for each cfg, wrap its instructions in a function and copy it to the binary
+        for cfg in &contract.cfg {
+            if cfg.name == "storage_initializer" {
+                Self::emit_storage_initializer(cfg, &mut bin);
+                continue;
+            }
+
+            if cfg.name.contains("constructor") {
+                continue;
+            }
+
+            let name = cfg.name.split("::").last().unwrap();
+            bin.miden_instrs
+                .as_ref()
+                .unwrap()
+                .borrow_mut()
+                .push(format!("export.{}", name));
+
+            for miden_instr in cfg.miden_instrs.iter() {
+                bin.miden_instrs
+                    .as_ref()
+                    .unwrap()
+                    .borrow_mut()
+                    .push(miden_instr.to_string());
+            }
+            bin.miden_instrs
+                .as_ref()
+                .unwrap()
+                .borrow_mut()
+                .push("end".to_string());
+        }
+
+        bin
+    }
+
+    pub fn emit_storage_initializer(cfg: &ControlFlowGraph, bin: &mut Binary) {
+        let use_miden_account = "use.miden::account";
+        let use_miden_sys = "use.std::sys";
+
+        bin.miden_instrs
+            .as_ref()
+            .unwrap()
+            .borrow_mut()
+            .insert(0, use_miden_account.to_string());
+        bin.miden_instrs
+            .as_ref()
+            .unwrap()
+            .borrow_mut()
+            .insert(1, use_miden_sys.to_string());
+
+        for instr in cfg.blocks[0].instr.iter().enumerate() {
+            if let Instr::SetStorage {
+                ty: _ty,
+                value: _value,
+                storage,
+                storage_type: _storage_type,
+            } = instr.1
+            {
+                if let Expression::NumberLiteral {
+                    loc: _loc,
+                    ty: _ty,
+                    value,
+                } = storage
+                {
+                    println!("Set storage at slot: {}", value);
+
+                    let miden_instr = format!("const.STORAGE_SLOT_{}={}", value, value);
+                    bin.miden_instrs
+                        .as_ref()
+                        .unwrap()
+                        .borrow_mut()
+                        .insert(instr.0 + 2, miden_instr);
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub enum Target {
     /// Ethereum EVM, see <https://ethereum.org/en/developers/docs/evm/>
     EVM,
     Soroban,
+    Miden,
 }
 
 impl fmt::Display for Target {
@@ -42,6 +43,7 @@ impl fmt::Display for Target {
             Target::Polkadot { .. } => write!(f, "Polkadot"),
             Target::EVM => write!(f, "EVM"),
             Target::Soroban => write!(f, "Soroban"),
+            Target::Miden => write!(f, "Miden"),
         }
     }
 }
@@ -55,6 +57,7 @@ impl PartialEq for Target {
             Target::Polkadot { .. } => matches!(other, Target::Polkadot { .. }),
             Target::EVM => matches!(other, Target::EVM),
             Target::Soroban => matches!(other, Target::Soroban),
+            Target::Miden => matches!(other, Target::Miden),
         }
     }
 }
@@ -88,6 +91,8 @@ impl Target {
         match self {
             // Solana uses ELF dynamic shared object (BPF)
             Target::Solana => "so",
+            // For Miden, file extension is .masm
+            Target::Miden => "masm",
             // Everything else generates webassembly
             _ => "wasm",
         }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -23,6 +23,7 @@ pub fn link(input: &[u8], name: &str, target: Target) -> Vec<u8> {
             address_length: _,
             value_length: _,
         } => polkadot_wasm::link(input, name),
+        Target::Miden => input.to_vec(),
         _ => panic!("linker not implemented for target {target:?}"),
     }
 }

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -42,6 +42,7 @@ impl Namespace {
             } => (address_length, value_length),
             Target::Solana => (32, 8),
             Target::Soroban => (32, 64),
+            Target::Miden => (32, 64),
         };
 
         let mut ns = Namespace {

--- a/src/sema/yul/builtin.rs
+++ b/src/sema/yul/builtin.rs
@@ -22,6 +22,7 @@ impl YulBuiltinPrototype {
             Target::EVM => self.availability[0],
             Target::Polkadot { .. } => self.availability[1],
             Target::Solana => self.availability[2],
+            Target::Miden => unimplemented!(),
             Target::Soroban => unimplemented!(),
         }
     }

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -102,7 +102,7 @@ fn parse_file(path: PathBuf, target: Target) -> io::Result<()> {
                         contract.emit(&ns, &Default::default(), contract_no)
                     }
                     Target::EVM => b"beep".to_vec(),
-                    Target::Soroban => {
+                    Target::Soroban | Target::Miden => {
                         todo!()
                     }
                 };


### PR DESCRIPTION
This PR is a proof of concept for supporting a counter contract in Miden Assembly (masm).

Some interesting notes: 
1- In Miden, each instruction either expects some input on the stack or takes an argument or both. To support this behavior, I added a `miden_stack` variable in `ControlFlowGraph` of each function, and updated it accordingly in each `Expression` or `Instr`

2- Storage in Miden is not initialized by the contract, the contract only references already existing storage (initialized by the Rust lient while creating the contract account). In Solang, each storage variable is assgined a `slot`. now Solang's built in `Storage initalizer` only emits var names with this format: `const.STORAGE_SLOT_0=0` in which this references the first storage index pre-defined by the Rust client.

3- To try this out, create a file named "counter.sol" and insert this code:
```
contract counter {
    // This references the first storage slot in Miden account storage
    uint32 count=0;

    function increment_count() public {
        count += 1;
    }

    function get_count() public view returns (uint32) {
        return count;
    }
}
```
Then, compile via: `solang compile counter.sol --target miden --release`
You then should see the `.masm` file which would look like:
```
use.miden::account
use.std::sys
const.STORAGE_SLOT_0=0
export.increment_count
    push.STORAGE_SLOT_0
    exec.account::get_item
    add.1
    push.STORAGE_SLOT_0
    exec.account::set_item
    exec.sys::truncate_stack
end
export.get_count
    push.STORAGE_SLOT_0
    exec.account::get_item
    exec.sys::truncate_stack
end
```
To deploy and interact with it, the most straightforward way is miden's rust client:
https://github.com/0xMiden/miden-tutorials/blob/main/rust-client/src/bin/counter_contract_increment.rs


